### PR TITLE
eslintの実行オプションにcacheとingoresを設定

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ styled-system
 styled-system-studio
 
 .npmrc
+
+.eslintcache

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -48,6 +48,7 @@ export default tsESLint.config(
       "**/.astro/",
       "**/.storybook/",
       "**/env.d.ts",
+      "**/*.config.ts",
     ],
   }
 );

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -11,7 +11,6 @@ const compat = new FlatCompat();
 export default tsESLint.config(
   ...compat.extends("plugin:storybook/recommended"),
   {
-    ignores: ["**/node_modules/**", "**/dist/**", "**/build/**"],
     plugins: {
       "react-refresh": reactRefresh,
       "@pandacss": pandaCss,
@@ -40,6 +39,8 @@ export default tsESLint.config(
   prettierRecommended,
   {
     ignores: [
+      "**/node_modules/",
+      "**/build/",
       "**/dist/",
       "**/styled-system/",
       "**/*.cjs",

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -11,6 +11,7 @@ const compat = new FlatCompat();
 export default tsESLint.config(
   ...compat.extends("plugin:storybook/recommended"),
   {
+    ignores: ["**/node_modules/**", "**/dist/**", "**/build/**"],
     plugins: {
       "react-refresh": reactRefresh,
       "@pandacss": pandaCss,

--- a/ui/package.json
+++ b/ui/package.json
@@ -10,7 +10,7 @@
     "build:panda": "panda codegen",
     "build:components": "vite build",
     "build": "npm run build:panda && npm run build:components",
-    "lint": "eslint . --report-unused-disable-directives --max-warnings 0",
+    "lint": "eslint . --cache --report-unused-disable-directives --max-warnings 0",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "storybook": "storybook dev -p 6006",

--- a/ui/package.json
+++ b/ui/package.json
@@ -10,7 +10,7 @@
     "build:panda": "panda codegen",
     "build:components": "vite build",
     "build": "npm run build:panda && npm run build:components",
-    "lint": "eslint . --cache --report-unused-disable-directives --max-warnings 0",
+    "lint": "eslint . --cache --report-unused-disable-directives --max-warnings 0 --debug",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "storybook": "storybook dev -p 6006",


### PR DESCRIPTION
lintに時間がかかるとの報告があったためオプションを見直します。