### PR TITLE
Hide the entire label element when there is no label

### DIFF
--- a/ui/src/components/TextArea.tsx
+++ b/ui/src/components/TextArea.tsx
@@ -130,10 +130,7 @@ export const TextArea = forwardRef<HTMLTextAreaElement, Props>(
         {label ? (
           <label className={styles.label}>
             {label}
-            {required && (
-              // とりあえず必須メッセージはハードコード
-              <span className={styles.required}>必須</span>
-            )}
+            {required && <span className={styles.required}>必須</span>}
           </label>
         ) : null}
         <div

--- a/ui/src/components/TextArea.tsx
+++ b/ui/src/components/TextArea.tsx
@@ -127,13 +127,15 @@ export const TextArea = forwardRef<HTMLTextAreaElement, Props>(
 
     return (
       <div className={cx(styles.root, className)}>
-        <label className={styles.label}>
-          {label}
-          {required && (
-            // とりあえず必須メッセージはハードコード
-            <span className={styles.required}>必須</span>
-          )}
-        </label>
+        {label ? (
+          <label className={styles.label}>
+            {label}
+            {required && (
+              // とりあえず必須メッセージはハードコード
+              <span className={styles.required}>必須</span>
+            )}
+          </label>
+        ) : null}
         <div
           className={styles.wrapper}
           data-invalid={invalid ? true : undefined}

--- a/ui/src/components/TextField.tsx
+++ b/ui/src/components/TextField.tsx
@@ -152,10 +152,7 @@ export const TextField = forwardRef<HTMLInputElement, Props>(
         {label ? (
           <label className={styles.label}>
             {label}
-            {required && (
-              // とりあえず必須メッセージはハードコード
-              <span className={styles.required}>必須</span>
-            )}
+            {required && <span className={styles.required}>必須</span>}
           </label>
         ) : null}
         <div

--- a/ui/src/components/TextField.tsx
+++ b/ui/src/components/TextField.tsx
@@ -149,13 +149,15 @@ export const TextField = forwardRef<HTMLInputElement, Props>(
 
     return (
       <div className={cx(styles.root, className)}>
-        <label className={styles.label}>
-          {label}
-          {required && (
-            // とりあえず必須メッセージはハードコード
-            <span className={styles.required}>必須</span>
-          )}
-        </label>
+        {label ? (
+          <label className={styles.label}>
+            {label}
+            {required && (
+              // とりあえず必須メッセージはハードコード
+              <span className={styles.required}>必須</span>
+            )}
+          </label>
+        ) : null}
         <div
           className={styles.inputWrapper}
           data-invalid={invalid ? true : undefined}


### PR DESCRIPTION
ref: https://github.com/serendie/internal/issues/474

TextFieldやTextAreaにて、ラベルを指定しない際に上部にgapが生じ、デザイン実装の際に影響を及ぼす問題を修正