### PR TITLE
DropdownMenuのpropsの変更

### DIFF
--- a/ui/src/components/DropdownMenu.stories.tsx
+++ b/ui/src/components/DropdownMenu.stories.tsx
@@ -27,9 +27,9 @@ const meta: Meta<typeof DropdownMenu> = {
       control: { type: "boolean" },
       defaultValue: false,
     },
-    isIconMenu: {
-      control: { type: "boolean" },
-      defaultValue: false,
+    styleType: {
+      control: { type: "inline-radio", options: ["default", "iconButton"] },
+      defaultValue: "default",
     },
   },
 };
@@ -95,7 +95,7 @@ export const Icon: Story = {
   render: Template,
   args: {
     title: "メニュータイトル",
-    isIconMenu: true,
+    styleType: "iconButton",
     icon: <SerendieSymbol name="menu" />,
   },
 };

--- a/ui/src/components/DropdownMenu.tsx
+++ b/ui/src/components/DropdownMenu.tsx
@@ -83,7 +83,7 @@ export type MenuItemProps = {
 };
 
 export type DropdownMenuProps = {
-  isIconMenu?: boolean;
+  styleType?: "default" | "iconButton";
   title: string;
   items: MenuItemProps[];
   disabled?: boolean;
@@ -91,7 +91,7 @@ export type DropdownMenuProps = {
 };
 
 export const DropdownMenu: React.FC<DropdownMenuProps & MenuRootProps> = ({
-  isIconMenu,
+  styleType = "default",
   title,
   items,
   disabled,
@@ -104,7 +104,7 @@ export const DropdownMenu: React.FC<DropdownMenuProps & MenuRootProps> = ({
   return (
     <ArkMenu.Root {...restProps}>
       <ArkMenu.Trigger asChild>
-        {isIconMenu ? (
+        {styleType === "iconButton" && (
           <IconButton
             icon={
               icon || (
@@ -118,8 +118,10 @@ export const DropdownMenu: React.FC<DropdownMenuProps & MenuRootProps> = ({
             shape="rectangle"
             disabled={disabled}
             styleType="outlined"
+            title={title}
           />
-        ) : (
+        )}
+        {styleType == "default" && (
           <Button
             styleType="rectangle"
             size="medium"

--- a/ui/src/components/DropdownMenu.tsx
+++ b/ui/src/components/DropdownMenu.tsx
@@ -104,7 +104,7 @@ export const DropdownMenu: React.FC<DropdownMenuProps & MenuRootProps> = ({
   return (
     <ArkMenu.Root {...restProps}>
       <ArkMenu.Trigger asChild>
-        {styleType === "iconButton" && (
+        {styleType === "iconButton" ? (
           <IconButton
             icon={
               icon || (
@@ -120,8 +120,7 @@ export const DropdownMenu: React.FC<DropdownMenuProps & MenuRootProps> = ({
             styleType="outlined"
             title={title}
           />
-        )}
-        {styleType == "default" && (
+        ) : (
           <Button
             styleType="rectangle"
             size="medium"


### PR DESCRIPTION
DropdownMenuのpropsの変更を行います。

これまで、Iconのメニューボタンを表示させる際には、`isIconMenu` を trueにすることで可能となっていましたが、
他コンポーネントなどとのAPIの整合性を合わせるため、`styleType = "iconButton"` へ変更します。

また、アクセシビリティの観点から、DropdownMenuで利用しているtitleも、IconButtonにてtitle属性として反映されるようになります。