### PR TITLE
Update design token modules

### DIFF
--- a/design-tokens/package.json
+++ b/design-tokens/package.json
@@ -11,7 +11,7 @@
     "release": "release-it --config ../.release-it.json"
   },
   "devDependencies": {
-    "@serendie/style-dictionary-formatter": "^0.0.5",
+    "@serendie/style-dictionary-formatter": "^0.0.6",
     "release-it": "^17.11.0",
     "style-dictionary": "^3.9.2",
     "style-dictionary-utils": "^2.0.7"

--- a/design-tokens/package.json
+++ b/design-tokens/package.json
@@ -2,7 +2,7 @@
   "name": "@serendie/design-token",
   "description": "Design tokens as part of Serendie Design System by Mitsubishi Electric",
   "license": "MIT",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "type": "module",
   "scripts": {
     "build": "tsx buildTokens.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "typescript": "^5.5.3"
       },
       "devDependencies": {
-        "@serendie/style-dictionary-formatter": "^0.0.5",
+        "@serendie/style-dictionary-formatter": "^0.0.6",
         "release-it": "^17.11.0",
         "style-dictionary": "^3.9.2",
         "style-dictionary-utils": "^2.0.7"
@@ -3059,9 +3059,9 @@
       }
     },
     "node_modules/@serendie/style-dictionary-formatter": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@serendie/style-dictionary-formatter/-/style-dictionary-formatter-0.0.5.tgz",
-      "integrity": "sha512-Bpx+W4yoRU/nZUho7zMtcUUt9d6qL0Q0YcmouIlkOf48EurBCJsN1UZdMHvYta0XNfxUC7ASeICbHQfu1jva4A==",
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@serendie/style-dictionary-formatter/-/style-dictionary-formatter-0.0.6.tgz",
+      "integrity": "sha512-iFEmZOwNUqYl26qhG5Liy3pmCNrkx/oOhV1hVAJqmIV+5n0j6jBFkhzEELFz+w46HdoX/SPyPm4x1CrjHIskag==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -17139,7 +17139,7 @@
     },
     "ui": {
       "name": "@serendie/ui",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "license": "MIT",
       "dependencies": {
         "@ark-ui/react": "^3.5.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -2,7 +2,7 @@
   "name": "@serendie/ui",
   "description": "Adaptive UI component library as part of Serendie Design System by Mitsubishi Electric",
   "license": "MIT",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "type": "module",
   "types": "./dist/index.d.ts",
   "scripts": {


### PR DESCRIPTION
1. #18 のバージョンアップに合わせてdesign-tokenで使用しているstyle-dictionary-formatterもバージョンアップしました
2. serendie/uiがすでに手動で0.1.10が出ているのでバージョン番号を実態に合わせました

この変更では、design-tokenに`sd.system.dimension.breakpoint.expanded`などのbreakpointの値が含まれるようになります。 ref: #11 

マージしたらdesign-tokenをnpm publishすること