### PR TITLE
メニュー位置の調整

### DIFF
--- a/ui/src/components/DropdownMenu.tsx
+++ b/ui/src/components/DropdownMenu.tsx
@@ -102,7 +102,15 @@ export const DropdownMenu: React.FC<DropdownMenuProps & MenuRootProps> = ({
   const styles = DropdownMenuStyle();
 
   return (
-    <ArkMenu.Root {...restProps}>
+    <ArkMenu.Root
+      positioning={{
+        offset: {
+          mainAxis: 1,
+          crossAxis: 0,
+        },
+      }}
+      {...restProps}
+    >
       <ArkMenu.Trigger asChild>
         {styleType === "iconButton" ? (
           <IconButton

--- a/ui/src/components/Search.tsx
+++ b/ui/src/components/Search.tsx
@@ -152,7 +152,18 @@ export const Search: React.FC<SearchStyleProps> = ({
   const styles = SearchStyle(variantProps);
 
   return (
-    <Combobox.Root items={items} lazyMount unmountOnExit {...elementProps}>
+    <Combobox.Root
+      items={items}
+      lazyMount
+      unmountOnExit
+      positioning={{
+        offset: {
+          mainAxis: 2,
+          crossAxis: 0,
+        },
+      }}
+      {...elementProps}
+    >
       <Combobox.Control className={cx(styles.control, elementProps.className)}>
         <div className={styles.iconBox}>
           <SerendieSymbol name="magnifying-glass" className={styles.icon} />

--- a/ui/src/components/Select.tsx
+++ b/ui/src/components/Select.tsx
@@ -174,7 +174,13 @@ export const Select: React.FC<SelectStyleProps> = ({
       {...elementProps}
       invalid={invalid}
       className={cx(styles.root, className)}
-      positioning={{ sameWidth: true }}
+      positioning={{
+        sameWidth: true,
+        offset: {
+          mainAxis: 1,
+          crossAxis: 0,
+        },
+      }}
     >
       {label && variantProps.size != "small" && (
         // smallの場合はラベルを表示しない


### PR DESCRIPTION
DropdownMenu、Search、Selectにて、クリックした際に表示されるメニューの位置を、
Figmaのデザインに合わせ調整しました。

ref: https://github.com/serendie/internal/issues/439