### PR TITLE
Use deploy key for release package workflow

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -29,6 +29,9 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
       - uses: actions/setup-node@v4
         with:
           node-version: 22


### PR DESCRIPTION
main branchにdirect pushを禁止するrule setsがあるとrelease-itがうまく動かない件を解決します。
以下でも議論があるようにGitHub Actions(GITHUB_TOKEN)を使用して上記を行う方法はいくつかあります。
- botユーザーを作成しそのPATを使う
  - 管理するのが大変
- pull requestを作ってマージする
  - release-itが対応していない
- deploy keyを使う
https://github.com/orgs/community/discussions/25305

その中でも今回はdeploy keyを利用する方法を採用しました。以下を参考に設定します。
https://github.com/sbellone/release-workflow-example
