### PR TITLE
Disable release note auto generation

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -7,7 +7,7 @@
   "github": {
     "release": true,
     "releaseName": "${npm.name}@${version}",
-    "autoGenerate": true
+    "autoGenerate": false
   },
   "hooks": {
     "after:bump": "npm run build"


### PR DESCRIPTION
モノレポだと正常にrelease-itによるリリースノート自動生成が動かないのでオフにします。