### PR TITLE
TextFieldコンポーネントにstartContentとendContentプロパティを追加、PasswordFieldコンポーネントを追加

### DIFF
--- a/ui/src/components/PasswordField.stories.tsx
+++ b/ui/src/components/PasswordField.stories.tsx
@@ -30,6 +30,8 @@ const meta: Meta<typeof PasswordField> = {
     required: true,
     disabled: false,
     invalid: false,
+    label: "パスワード",
+    placeholder: "パスワードを入力",
     invalidMessage: "パスワードは8文字以上必要です",
     description:
       "大文字、小文字、数字を含む8文字以上のパスワードを設定してください",

--- a/ui/src/components/PasswordField.stories.tsx
+++ b/ui/src/components/PasswordField.stories.tsx
@@ -1,29 +1,59 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { PasswordField } from "./PasswordField";
 import figma from "@figma/code-connect";
+import { TextField } from "./TextField";
 
 const meta: Meta<typeof PasswordField> = {
   component: PasswordField,
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/8oZpZ2xolRhCUPDGSlWXr0/%F0%9F%9B%A0%EF%B8%8F-Serendie-UI-Kit?node-id=17427-3758&t=RkaxamT0s6oqwyiL-4",
+      props: {
+        textField: figma.nestedProps("TextField", {
+          label: figma.string("Label"),
+          disabled: figma.enum("State", { Disabled: true }),
+          invalid: figma.enum("State", { Error: true }),
+          invalidMessage: figma.string("InvalidMessage"),
+          description: figma.string("Description"),
+          placeholder: figma.string("Placeholder"),
+          required: figma.boolean("Required"),
+        }),
+      },
+      examples: [FigmaExample],
+    },
     controls: {
       expanded: true,
     },
   },
   args: {
-    label: "パスワード",
     required: true,
     disabled: false,
     invalid: false,
     invalidMessage: "パスワードは8文字以上必要です",
     description:
       "大文字、小文字、数字を含む8文字以上のパスワードを設定してください",
-    placeholder: "パスワードを入力",
     disableToggle: false,
   },
 };
 
-function FigmaExample(props: React.ComponentProps<typeof PasswordField>) {
-  return <PasswordField {...props} />;
+function FigmaExample(
+  props: React.ComponentProps<typeof PasswordField> & {
+    textField: React.ComponentProps<typeof TextField>;
+  }
+) {
+  return (
+    <PasswordField
+      label={props.textField.label}
+      disabled={props.textField.disabled}
+      invalid={props.textField.invalid}
+      invalidMessage={props.textField.invalidMessage}
+      description={props.textField.description}
+      placeholder={props.textField.placeholder}
+      required={props.textField.required}
+      {...props}
+    />
+  );
 }
 
 export default meta;

--- a/ui/src/components/PasswordField.stories.tsx
+++ b/ui/src/components/PasswordField.stories.tsx
@@ -5,21 +5,6 @@ import figma from "@figma/code-connect";
 const meta: Meta<typeof PasswordField> = {
   component: PasswordField,
   parameters: {
-    design: {
-      type: "figma",
-      url: "https://www.figma.com/design/8oZpZ2xolRhCUPDGSlWXr0/Serendie-UI-Kit?node-id=5113-4273",
-      props: {
-        label: figma.string("Label"),
-        disabled: figma.enum("State", { Disabled: true }),
-        invalid: figma.enum("State", { Error: true }),
-        invalidMessage: figma.string("InvalidMessage"),
-        description: figma.string("Description"),
-        placeholder: figma.string("Placeholder"),
-        required: figma.boolean("Required"),
-        disableToggle: figma.boolean("DisableToggle"),
-      },
-      examples: [FigmaExample],
-    },
     controls: {
       expanded: true,
     },

--- a/ui/src/components/PasswordField.stories.tsx
+++ b/ui/src/components/PasswordField.stories.tsx
@@ -1,0 +1,71 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { PasswordField } from "./PasswordField";
+import figma from "@figma/code-connect";
+
+const meta: Meta<typeof PasswordField> = {
+  component: PasswordField,
+  parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/8oZpZ2xolRhCUPDGSlWXr0/Serendie-UI-Kit?node-id=5113-4273",
+      props: {
+        label: figma.string("Label"),
+        disabled: figma.enum("State", { Disabled: true }),
+        invalid: figma.enum("State", { Error: true }),
+        invalidMessage: figma.string("InvalidMessage"),
+        description: figma.string("Description"),
+        placeholder: figma.string("Placeholder"),
+        required: figma.boolean("Required"),
+        disableToggle: figma.boolean("DisableToggle"),
+      },
+      examples: [FigmaExample],
+    },
+    controls: {
+      expanded: true,
+    },
+  },
+  args: {
+    label: "パスワード",
+    required: true,
+    disabled: false,
+    invalid: false,
+    invalidMessage: "パスワードは8文字以上必要です",
+    description:
+      "大文字、小文字、数字を含む8文字以上のパスワードを設定してください",
+    placeholder: "パスワードを入力",
+    disableToggle: false,
+  },
+};
+
+function FigmaExample(props: React.ComponentProps<typeof PasswordField>) {
+  return <PasswordField {...props} />;
+}
+
+export default meta;
+type Story = StoryObj<typeof PasswordField>;
+
+export const Basic: Story = {};
+
+export const DisabledToggle: Story = {
+  args: {
+    disableToggle: true,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+  },
+};
+
+export const HasError: Story = {
+  args: {
+    invalid: true,
+  },
+};
+
+export const WithoutLabel: Story = {
+  args: {
+    label: undefined,
+  },
+};

--- a/ui/src/components/PasswordField.tsx
+++ b/ui/src/components/PasswordField.tsx
@@ -5,7 +5,7 @@ import { IconButton } from "./IconButton";
 
 type PasswordFieldProps = Omit<
   React.ComponentProps<typeof TextField>,
-  "type" | "endContent"
+  "type" | "rightContent"
 > & {
   /**
    * パスワードの表示/非表示切り替えを無効にする
@@ -14,7 +14,16 @@ type PasswordFieldProps = Omit<
 };
 
 export const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
-  ({ disableToggle = false, ...props }, ref) => {
+  (
+    {
+      disableToggle = false,
+      disabled,
+      label = "パスワード",
+      placeholder = "パスワードを入力",
+      ...props
+    },
+    ref
+  ) => {
     const [showPassword, setShowPassword] = useState(false);
 
     const togglePasswordVisibility = () => {
@@ -29,6 +38,7 @@ export const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
         size="small"
         shape="circle"
         aria-label={showPassword ? "パスワードを隠す" : "パスワードを表示"}
+        disabled={disabled}
         icon={
           <SerendieSymbol
             name={showPassword ? "eye-hidden" : "eye"}
@@ -41,7 +51,10 @@ export const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
     return (
       <TextField
         type={showPassword ? "text" : "password"}
-        endContent={toggleButton}
+        rightContent={toggleButton}
+        disabled={disabled}
+        label={label}
+        placeholder={placeholder}
         {...props}
         ref={ref}
       />

--- a/ui/src/components/PasswordField.tsx
+++ b/ui/src/components/PasswordField.tsx
@@ -1,0 +1,51 @@
+import React, { forwardRef, useState } from "react";
+import { TextField } from "./TextField";
+import { SerendieSymbol } from "@serendie/symbols";
+import { IconButton } from "./IconButton";
+
+type PasswordFieldProps = Omit<
+  React.ComponentProps<typeof TextField>,
+  "type" | "endContent"
+> & {
+  /**
+   * パスワードの表示/非表示切り替えを無効にする
+   */
+  disableToggle?: boolean;
+};
+
+export const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
+  ({ disableToggle = false, ...props }, ref) => {
+    const [showPassword, setShowPassword] = useState(false);
+
+    const togglePasswordVisibility = () => {
+      setShowPassword((prev) => !prev);
+    };
+
+    const toggleButton = !disableToggle ? (
+      <IconButton
+        type="button"
+        onClick={togglePasswordVisibility}
+        styleType="ghost"
+        size="small"
+        aria-label={showPassword ? "パスワードを隠す" : "パスワードを表示"}
+        icon={
+          <SerendieSymbol
+            name={showPassword ? "eye-hidden" : "eye"}
+            size={20}
+          />
+        }
+      />
+    ) : undefined;
+
+    return (
+      <TextField
+        type={showPassword ? "text" : "password"}
+        endContent={toggleButton}
+        {...props}
+        ref={ref}
+      />
+    );
+  }
+);
+
+PasswordField.displayName = "PasswordField";

--- a/ui/src/components/PasswordField.tsx
+++ b/ui/src/components/PasswordField.tsx
@@ -14,16 +14,7 @@ type PasswordFieldProps = Omit<
 };
 
 export const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
-  (
-    {
-      disableToggle = false,
-      disabled,
-      label = "パスワード",
-      placeholder = "パスワードを入力",
-      ...props
-    },
-    ref
-  ) => {
+  ({ disableToggle = false, disabled, ...props }, ref) => {
     const [showPassword, setShowPassword] = useState(false);
 
     const togglePasswordVisibility = () => {
@@ -53,8 +44,6 @@ export const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
         type={showPassword ? "text" : "password"}
         rightContent={toggleButton}
         disabled={disabled}
-        label={label}
-        placeholder={placeholder}
         {...props}
         ref={ref}
       />

--- a/ui/src/components/PasswordField.tsx
+++ b/ui/src/components/PasswordField.tsx
@@ -27,6 +27,7 @@ export const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
         onClick={togglePasswordVisibility}
         styleType="ghost"
         size="small"
+        shape="circle"
         aria-label={showPassword ? "パスワードを隠す" : "パスワードを表示"}
         icon={
           <SerendieSymbol

--- a/ui/src/components/TextField.stories.tsx
+++ b/ui/src/components/TextField.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { TextField } from "./TextField";
 import figma from "@figma/code-connect";
 import { SerendieSymbol } from "@serendie/symbols";
+import { Box } from "../../styled-system/jsx";
 
 const meta: Meta<typeof TextField> = {
   component: TextField,
@@ -59,24 +60,39 @@ export const HasError: Story = {
   },
 };
 
-export const WithStartContent: Story = {
+export const WithleftContent: Story = {
   args: {
-    startContent: <SerendieSymbol name='magnifying-glass' size={20} />,
+    leftContent: <SerendieSymbol name="magnifying-glass" size={20} />,
     placeholder: "検索キーワードを入力",
   },
 };
 
-export const WithEndContent: Story = {
+export const WithrightContent: Story = {
   args: {
-    endContent: <SerendieSymbol name='information' size={20} />,
+    rightContent: <SerendieSymbol name="information" size={20} />,
     placeholder: "情報を入力",
   },
 };
 
 export const WithBothContents: Story = {
   args: {
-    startContent: <SerendieSymbol name="mail" size={20} />,
-    endContent: <SerendieSymbol name='information' size={20} />,
+    leftContent: <SerendieSymbol name="mail" size={20} />,
+    rightContent: <SerendieSymbol name="information" size={20} />,
     placeholder: "メールアドレスを入力",
+  },
+};
+
+export const WithText: Story = {
+  args: {
+    leftContent: (
+      <Box
+        textStyle="sd.system.typography.label.medium_compact"
+        color={"sd.system.color.component.onSurfaceVariant"}
+      >
+        serendie.design/
+      </Box>
+    ),
+    placeholder: "URLを入力",
+    label: "URL",
   },
 };

--- a/ui/src/components/TextField.stories.tsx
+++ b/ui/src/components/TextField.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { TextField } from "./TextField";
 import figma from "@figma/code-connect";
+import { SerendieSymbol } from "@serendie/symbols";
 
 const meta: Meta<typeof TextField> = {
   component: TextField,
@@ -55,5 +56,27 @@ export const Disabled: Story = {
 export const HasError: Story = {
   args: {
     invalid: true,
+  },
+};
+
+export const WithStartContent: Story = {
+  args: {
+    startContent: <SerendieSymbol name='magnifying-glass' size={20} />,
+    placeholder: "検索キーワードを入力",
+  },
+};
+
+export const WithEndContent: Story = {
+  args: {
+    endContent: <SerendieSymbol name='information' size={20} />,
+    placeholder: "情報を入力",
+  },
+};
+
+export const WithBothContents: Story = {
+  args: {
+    startContent: <SerendieSymbol name="mail" size={20} />,
+    endContent: <SerendieSymbol name='information' size={20} />,
+    placeholder: "メールアドレスを入力",
   },
 };

--- a/ui/src/components/TextField.tsx
+++ b/ui/src/components/TextField.tsx
@@ -10,8 +10,8 @@ const TextFieldStyle = sva({
     "label",
     "required",
     "inputWrapper",
-    "startContent",
-    "endContent",
+    "leftContent",
+    "rightContent",
     "input",
     "icon",
     "messageField",
@@ -64,10 +64,10 @@ const TextFieldStyle = sva({
         outlineColor: "sd.system.color.impression.negative",
       },
     },
-    startContent: {
+    leftContent: {
       paddingLeft: "sd.system.dimension.spacing.medium",
     },
-    endContent: {
+    rightContent: {
       paddingRight: "sd.system.dimension.spacing.medium",
     },
     input: {
@@ -108,8 +108,8 @@ type Props = {
   description?: string;
   invalid?: boolean;
   invalidMessage?: string;
-  startContent?: React.ReactNode;
-  endContent?: React.ReactNode;
+  leftContent?: React.ReactNode;
+  rightContent?: React.ReactNode;
 } & React.ComponentPropsWithoutRef<"input">;
 
 export const TextField = forwardRef<HTMLInputElement, Props>(
@@ -126,8 +126,8 @@ export const TextField = forwardRef<HTMLInputElement, Props>(
       onChange,
       value,
       className,
-      startContent,
-      endContent,
+      leftContent,
+      rightContent,
       ...props
     },
     ref
@@ -173,8 +173,8 @@ export const TextField = forwardRef<HTMLInputElement, Props>(
           data-invalid={invalid ? true : undefined}
           data-disabled={disabled ? true : undefined}
         >
-          {startContent ? (
-            <div className={styles.startContent}>{startContent}</div>
+          {leftContent ? (
+            <div className={styles.leftContent}>{leftContent}</div>
           ) : (
             <div></div>
           )}
@@ -190,8 +190,8 @@ export const TextField = forwardRef<HTMLInputElement, Props>(
             onChange={onValueChange}
             {...elementProps}
           />
-          {endContent ? (
-            <div className={styles.endContent}>{endContent}</div>
+          {rightContent ? (
+            <div className={styles.rightContent}>{rightContent}</div>
           ) : (
             <div className={styles.icon}>
               {!disabled &&

--- a/ui/src/components/TextField.tsx
+++ b/ui/src/components/TextField.tsx
@@ -10,6 +10,8 @@ const TextFieldStyle = sva({
     "label",
     "required",
     "inputWrapper",
+    "startContent",
+    "endContent",
     "input",
     "icon",
     "messageField",
@@ -39,7 +41,7 @@ const TextFieldStyle = sva({
     inputWrapper: {
       height: 48,
       display: "grid",
-      gridTemplateColumns: "1fr auto",
+      gridTemplateColumns: "auto 1fr auto auto",
       alignItems: "center",
       outlineStyle: "solid",
       outlineWidth: "sd.system.dimension.border.medium",
@@ -61,6 +63,12 @@ const TextFieldStyle = sva({
       _invalid: {
         outlineColor: "sd.system.color.impression.negative",
       },
+    },
+    startContent: {
+      paddingLeft: "sd.system.dimension.spacing.medium",
+    },
+    endContent: {
+      paddingRight: "sd.system.dimension.spacing.medium",
     },
     input: {
       outline: "none",
@@ -100,6 +108,8 @@ type Props = {
   description?: string;
   invalid?: boolean;
   invalidMessage?: string;
+  startContent?: React.ReactNode;
+  endContent?: React.ReactNode;
 } & React.ComponentPropsWithoutRef<"input">;
 
 export const TextField = forwardRef<HTMLInputElement, Props>(
@@ -116,6 +126,8 @@ export const TextField = forwardRef<HTMLInputElement, Props>(
       onChange,
       value,
       className,
+      startContent,
+      endContent,
       ...props
     },
     ref
@@ -161,6 +173,11 @@ export const TextField = forwardRef<HTMLInputElement, Props>(
           data-invalid={invalid ? true : undefined}
           data-disabled={disabled ? true : undefined}
         >
+          {startContent ? (
+            <div className={styles.startContent}>{startContent}</div>
+          ) : (
+            <div></div>
+          )}
           <input
             ref={mergedRef}
             id={inputId}
@@ -173,27 +190,31 @@ export const TextField = forwardRef<HTMLInputElement, Props>(
             onChange={onValueChange}
             {...elementProps}
           />
-          <div className={styles.icon}>
-            {!disabled &&
-              /* disabledの場合はアイコンを表示しない */
-              (invalid ? (
-                <span
-                  className={css({
-                    color: "sd.system.color.impression.negative",
-                  })}
-                >
-                  <SerendieSymbol name="alert-circle" size={20} />
-                </span>
-              ) : _value ? (
-                <button
-                  className={css({ cursor: "pointer" })}
-                  onClick={resetValue}
-                  aria-label="値をクリア"
-                >
-                  <SerendieSymbol name="close" size={20} />
-                </button>
-              ) : null)}
-          </div>
+          {endContent ? (
+            <div className={styles.endContent}>{endContent}</div>
+          ) : (
+            <div className={styles.icon}>
+              {!disabled &&
+                /* disabledの場合はアイコンを表示しない */
+                (invalid ? (
+                  <span
+                    className={css({
+                      color: "sd.system.color.impression.negative",
+                    })}
+                  >
+                    <SerendieSymbol name="alert-circle" size={20} />
+                  </span>
+                ) : _value ? (
+                  <button
+                    className={css({ cursor: "pointer" })}
+                    onClick={resetValue}
+                    aria-label="値をクリア"
+                  >
+                    <SerendieSymbol name="close" size={20} />
+                  </button>
+                ) : null)}
+            </div>
+          )}
         </div>
         {showMessageField && (
           <div className={styles.messageField}>


### PR DESCRIPTION
ref: https://github.com/serendie/internal/issues/501

TextFieldにstartContentとendContentプロパティを追加し、
パスワード入力画面を作る際に便利なPasswordFieldコンポーネントを追加しました。