### PR TITLE
Support per-module import for Accordion

### DIFF
--- a/src/components/Accordion/Accordion.stories.tsx
+++ b/src/components/Accordion/Accordion.stories.tsx
@@ -1,7 +1,7 @@
-import { Meta, StoryObj } from "@storybook/react";
-import { Accordion, AccordionProps } from "./Accordion";
-import { AccordionGroup } from "./AccordionGroup";
 import figma from "@figma/code-connect";
+import { Meta, StoryObj } from "@storybook/react";
+import { AccordionGroup } from "../AccordionGroup";
+import { Accordion, AccordionProps } from "./Accordion";
 
 const meta: Meta<typeof Accordion> = {
   component: Accordion,

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -1,7 +1,7 @@
-import { sva } from "../../styled-system/css";
 import { AccordionItemProps, Accordion as ArkAccordion } from "@ark-ui/react";
-import { RecipeVariantProps } from "../../styled-system/types";
 import { SerendieSymbol } from "@serendie/symbols";
+import { sva } from "../../../styled-system/css";
+import { RecipeVariantProps } from "../../../styled-system/types";
 
 const AccordionStyle = sva({
   slots: ["item", "title", "itemIndicator", "icon", "description"],

--- a/src/components/Accordion/index.ts
+++ b/src/components/Accordion/index.ts
@@ -1,0 +1,1 @@
+export * as Accordion from "./Accordion";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 export { SerendiePreset } from "./preset";
 
-export * from "./components/Accordion.tsx";
+export * from "./components/Accordion";
 export * from "./components/AccordionGroup.tsx";
 export * from "./components/Avatar.tsx";
 export * from "./components/Badge.tsx";


### PR DESCRIPTION
tree shakingが適切にできるように `import { Accordion } from "@serendie/ui/Accordion";` という形でimportできるようにexport方法を調整しました。