### PR TITLE
Add indeterminate state to ChoiceBox

### DIFF
--- a/src/assets/checkboxIndeterminate.svg
+++ b/src/assets/checkboxIndeterminate.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M3.25 6C3.25 4.48122 4.48122 3.25 6 3.25H18C19.5188 3.25 20.75 4.48122 20.75 6V18C20.75 19.5188 19.5188 20.75 18 20.75H6C4.48122 20.75 3.25 19.5188 3.25 18V6Z" fill="currentColor"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M17 12.75H7V11.25H17V12.75Z" fill="currentColor" className="checkmark" />
+</svg>

--- a/src/components/ChoiceBox/ChoiceBox.stories.tsx
+++ b/src/components/ChoiceBox/ChoiceBox.stories.tsx
@@ -51,3 +51,11 @@ export const Checkbox: Story = {
     type: "checkbox",
   },
 };
+
+export const Indeterminate: Story = {
+  args: {
+    value: "itemA",
+    type: "checkbox",
+    indeterminate: true,
+  },
+};

--- a/src/components/ChoiceBox/ChoiceBox.tsx
+++ b/src/components/ChoiceBox/ChoiceBox.tsx
@@ -7,6 +7,7 @@ import {
 import { cx, sva } from "../../../styled-system/css";
 import CheckboxCheckedIcon from "../../assets/checkboxChecked.svg?react";
 import CheckboxUncheckedIcon from "../../assets/checkboxUnchecked.svg?react";
+import CheckboxIndeterminateIcon from "../../assets/checkboxIndeterminate.svg?react";
 import RadioChecked from "../../assets/radioChecked.svg?react";
 import RadioUnChecked from "../../assets/radioUnchecked.svg?react";
 import {
@@ -19,6 +20,7 @@ import {
   radioIconCss,
   radioUncheckedIconCss,
 } from "../RadioButton";
+import { useEffect, useRef } from "react";
 
 export const ChoiceBoxStyle = sva({
   slots: [
@@ -49,11 +51,14 @@ type ChoiceBoxBaseProps = {
 
 export type ChoiceBoxProps = ChoiceBoxBaseProps &
   RadioGroupItemProps &
-  CheckboxRootProps;
+  CheckboxRootProps & {
+    indeterminate?: boolean;
+  };
 
 export const ChoiceBox: React.FC<ChoiceBoxProps> = ({
   type,
   value,
+  indeterminate,
   className,
   ...props
 }) => {
@@ -84,17 +89,40 @@ export const ChoiceBox: React.FC<ChoiceBoxProps> = ({
   }
 
   if (type === "checkbox") {
+    const inputRef = useRef<HTMLInputElement>(null);
+    useEffect(() => {
+      if (inputRef.current) {
+        inputRef.current.indeterminate = !!indeterminate;
+      }
+    }, [indeterminate]);
+
     return (
       <ArkCheckbox.Root
         value={value}
         className={cx("group", styles.root, className)}
         {...elementProps}
+        onClick={(e) => {
+          if (indeterminate) {
+            e.preventDefault();
+            if (typeof props.onClick === "function") {
+              props.onClick(e);
+            }
+            return;
+          }
+          if (typeof props.onClick === "function") {
+            props.onClick(e);
+          }
+        }}
       >
         <ArkCheckbox.Context>
           {(checkbox) => (
             <ArkCheckbox.Control className={styles.checkboxItem}>
               {checkbox.checked ? (
                 <CheckboxCheckedIcon className={styles.checkboxCheckedIcon} />
+              ) : indeterminate ? (
+                <CheckboxIndeterminateIcon
+                  className={styles.checkboxCheckedIcon}
+                />
               ) : (
                 <CheckboxUncheckedIcon
                   className={styles.checkboxUncheckedIcon}
@@ -103,7 +131,7 @@ export const ChoiceBox: React.FC<ChoiceBoxProps> = ({
             </ArkCheckbox.Control>
           )}
         </ArkCheckbox.Context>
-        <ArkCheckbox.HiddenInput />
+        <ArkCheckbox.HiddenInput ref={inputRef} />
       </ArkCheckbox.Root>
     );
   }


### PR DESCRIPTION
ChoiceBoxにindeterminate状態(不確定状態)を追加しました。
ChoiceBoxコンポーネントに、チェックボックスの不確定状態を管理するためのプロパティを追加しました。
新しいSVGアイコンを追加し、状態に応じて表示を切り替えます。

Fixes https://linear.app/serendie/issue/SD-18/choiceboxinterminate