### PR TITLE
pkg.pr.new用の設定ファイルを追加

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -2,17 +2,29 @@ name: Publish to pkg.pr.new
 on:
   workflow_dispatch:
   pull_request:
-    branches: [main]
-    paths: [".github/workflows/pkg-pr-new.yml"]
+    paths:
+      - "src/**"
+      - "package.json"
+      - "package-lock.json"
+
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
-  build:
+  publish-to-pkg-pr-new:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -1,4 +1,4 @@
-name: Publish Any Commit
+name: Publish to pkg.pr.new
 on: [workflow_dispatch]
 
 jobs:

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -9,7 +9,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   publish-to-pkg-pr-new:

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -1,0 +1,20 @@
+name: Publish Any Commit
+on: [workflow_dispatch]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm build
+
+      - name: Publish
+        run: npx -y pkg-pr-new publish

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -1,5 +1,9 @@
 name: Publish to pkg.pr.new
-on: [workflow_dispatch, push, pull_request]
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+    paths: [".github/workflows/pkg-pr-new.yml"]
 
 jobs:
   build:
@@ -14,7 +18,7 @@ jobs:
         run: npm ci
 
       - name: Build
-        run: npm build
+        run: npm run build
 
       - name: Publish
         run: npx -y pkg-pr-new publish

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -1,5 +1,5 @@
 name: Publish to pkg.pr.new
-on: [workflow_dispatch]
+on: [workflow_dispatch, push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
開発中のSDSのビルドを他の作業レポジトリから参照しやすくするために https://pkg.pr.new/ を導入します。PR毎にパッケージがビルドされ

```sh
npm i https://pkg.pr.new/serendie/serendie/@serendie/ui@f694b38
```

のようにインストールできます。 [実行例](https://github.com/serendie/serendie/actions/runs/16039582156/job/45258554791)

実行範囲は serendie/serendie に絞っているので、 symbolsなどで使いたい場合は↓で対象レポジトリを追加する必要があります。
https://github.com/organizations/serendie/settings/installations/74100690