### PR TITLE
selectのcollectionプロパティをoptionalに変更

### DIFF
--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -153,6 +153,7 @@ type Props = {
   required?: boolean;
   invalidMessage?: string;
   items?: selectItem[];
+  collection?: SelectRootProps<selectItem>["collection"];
 };
 
 type selectItem = {
@@ -161,7 +162,7 @@ type selectItem = {
 };
 
 type SelectStyleProps = Props &
-  SelectRootProps<selectItem> &
+  Omit<SelectRootProps<selectItem>, "collection"> &
   RecipeVariantProps<typeof SelectStyle>;
 
 export const Select: React.FC<SelectStyleProps> = ({


### PR DESCRIPTION
異なるtypescritpのバージョン下で型チェックが通らないため、明示的にオプショナルに変更。
下位互換のため `items` を使っているが今後の方針は要検討