### PR TITLE
Paginationコンポーネントの内部でbuttonが入れ子になってしまう問題を修正

### DIFF
--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -19,14 +19,11 @@ export const PaginationStyle = sva({
       height: 32,
       minWidth: 32,
       margin: 0,
-      "& button": {
-        color: "sd.system.color.impression.primary",
-      },
+      color: "sd.system.color.impression.primary",
+
       "&[data-selected]": {
-        "& button": {
-          color: "sd.system.color.interaction.disabledOnSurface",
-          fontWeight: "bold",
-        },
+        color: "sd.system.color.interaction.disabledOnSurface",
+        fontWeight: "bold",
       },
     },
     ellipsis: {
@@ -143,6 +140,7 @@ export const Pagination = React.forwardRef<HTMLDivElement, PaginationProps>(
                 <ArkPagination.PrevTrigger
                   className={styles.prevTrigger}
                   disabled={isFirstPage}
+                  asChild
                 >
                   <IconButton
                     icon={<SerendieSymbolChevronLeft />}
@@ -163,6 +161,7 @@ export const Pagination = React.forwardRef<HTMLDivElement, PaginationProps>(
                       key={index}
                       {...page}
                       className={styles.item}
+                      asChild
                     >
                       <IconButton
                         icon={<>{page.value}</>}
@@ -187,6 +186,7 @@ export const Pagination = React.forwardRef<HTMLDivElement, PaginationProps>(
                 <ArkPagination.NextTrigger
                   className={styles.nextTrigger}
                   disabled={isLastPage}
+                  asChild
                 >
                   <IconButton
                     icon={<SerendieSymbolChevronRight />}


### PR DESCRIPTION
## 概要

Paginationのボタンが階層上入れ子になってしまい、Button要素内部にButton要素が入ってしまう問題を修正。
こちらの修正を行うことによって、ハイドレーションエラーが発生していたNext.js等のSSG/SSR環境でも問題なく利用できるようになります。

<img width="379" height="310" alt="image" src="https://github.com/user-attachments/assets/7ca90bf6-6e04-4933-abe5-36f7e8f5ed08" />

## 参考
- Pagination | Ark UI
  - https://ark-ui.com/docs/components/pagination