### PR TITLE
ModalDialog に キャンセルボタンを非表示にするプロパティを追加 / モーダルを閉じる動作の無効化に関するストーリーの追加

### DIFF
--- a/src/components/ModalDialog/ModalDialog.stories.tsx
+++ b/src/components/ModalDialog/ModalDialog.stories.tsx
@@ -108,3 +108,87 @@ export const PlayClickedButton: Story = {
     });
   },
 };
+
+export const PreventCloseOnEscape: Story = {
+  render: (args) => {
+    const [isOpen, setIsOpen] = useState(false);
+    return (
+      <>
+        <Button onClick={() => setIsOpen(true)}>Open Dialog</Button>
+        <ModalDialog
+          {...args}
+          isOpen={isOpen}
+          onOpenChange={(e) => setIsOpen(e.open)}
+          onButtonClick={() => {
+            alert("Button clicked");
+            setIsOpen(false);
+          }}
+          closeOnEscape={false}
+        />
+      </>
+    );
+  },
+  args: {
+    title: "Dialog (closeOnEscape=false)",
+    cancelButtonLabel: "Close",
+    submitButtonLabel: "Submit",
+    children: "Escキーではモーダルを閉じることができません。",
+  },
+};
+
+export const PreventCloseOnInteractOutside: Story = {
+  render: (args) => {
+    const [isOpen, setIsOpen] = useState(false);
+    return (
+      <>
+        <Button onClick={() => setIsOpen(true)}>Open Dialog</Button>
+        <ModalDialog
+          {...args}
+          isOpen={isOpen}
+          onOpenChange={(e) => setIsOpen(e.open)}
+          onButtonClick={() => {
+            alert("Button clicked");
+            setIsOpen(false);
+          }}
+          closeOnInteractOutside={false}
+          hideCancelButton
+        />
+      </>
+    );
+  },
+  args: {
+    title: "Dialog (closeOnInteractOutside=false)",
+    submitButtonLabel: "Submit",
+    children:
+      "バックドロップをクリックしてもモーダルを閉じることができません。",
+  },
+};
+
+export const PreventAllAutoClose: Story = {
+  render: (args) => {
+    const [isOpen, setIsOpen] = useState(false);
+    return (
+      <>
+        <Button onClick={() => setIsOpen(true)}>Open Dialog</Button>
+        <ModalDialog
+          {...args}
+          isOpen={isOpen}
+          onOpenChange={(e) => setIsOpen(e.open)}
+          onButtonClick={() => {
+            alert("Button clicked");
+            setIsOpen(false);
+          }}
+          closeOnEscape={false}
+          closeOnInteractOutside={false}
+        />
+      </>
+    );
+  },
+  args: {
+    title: "Dialog (both disabled)",
+    cancelButtonLabel: "Close",
+    submitButtonLabel: "Submit",
+    children:
+      "Escキーとバックドロップクリックの両方が無効化されています。ボタンでのみ閉じることができます。",
+  },
+};

--- a/src/components/ModalDialog/ModalDialog.tsx
+++ b/src/components/ModalDialog/ModalDialog.tsx
@@ -76,8 +76,9 @@ type Props = {
   children: React.ReactNode;
   className?: string;
   cancelButtonLabel?: string;
-  submitButtonLabel: string;
-  onButtonClick: () => void;
+  submitButtonLabel?: string;
+  onButtonClick?: () => void;
+  hideCancelButton?: boolean;
 };
 
 export type ModalDialogProps = Props &
@@ -92,9 +93,12 @@ export const ModalDialog: React.FC<ModalDialogProps> = ({
   onButtonClick,
   children,
   className,
+  hideCancelButton = false,
   ...rest
 }) => {
   const styles = ModalDialogStyle(rest);
+  const showButtons = submitButtonLabel || !hideCancelButton;
+
   return (
     <Dialog.Root open={isOpen} {...rest}>
       <Portal>
@@ -107,14 +111,20 @@ export const ModalDialog: React.FC<ModalDialogProps> = ({
                 {children}
               </Dialog.Description>
             </div>
-            <div className={styles.buttonWrapper}>
-              <Button onClick={onButtonClick}>{submitButtonLabel}</Button>
-              <Dialog.CloseTrigger asChild>
-                <Button styleType="ghost">
-                  {cancelButtonLabel || "閉じる"}
-                </Button>
-              </Dialog.CloseTrigger>
-            </div>
+            {showButtons && (
+              <div className={styles.buttonWrapper}>
+                {submitButtonLabel && (
+                  <Button onClick={onButtonClick}>{submitButtonLabel}</Button>
+                )}
+                {!hideCancelButton && (
+                  <Dialog.CloseTrigger asChild>
+                    <Button styleType="ghost">
+                      {cancelButtonLabel || "閉じる"}
+                    </Button>
+                  </Dialog.CloseTrigger>
+                )}
+              </div>
+            )}
           </Dialog.Content>
         </Dialog.Positioner>
       </Portal>


### PR DESCRIPTION
新しいストーリーを追加し、モーダルダイアログの動作を制御する機能を実装しました。
- Escapeキーでの閉じる動作を無効化するストーリーを追加
- バックドロップクリックでの閉じる動作を無効化するストーリーを追加
- 両方の自動閉じる動作を無効化するストーリーを追加
- ModalDialogコンポーネントにhideCancelButtonプロパティを追加