### PR TITLE
TextArea と TextField に fullwidth Propsを追加

### DIFF
--- a/src/components/TextArea/TextArea.stories.tsx
+++ b/src/components/TextArea/TextArea.stories.tsx
@@ -59,3 +59,9 @@ export const AutoAdjustHeight: Story = {
     autoAdjustHeight: true,
   },
 };
+
+export const FullWidth: Story = {
+  args: {
+    fullWidth: true,
+  },
+};

--- a/src/components/TextArea/TextArea.tsx
+++ b/src/components/TextArea/TextArea.tsx
@@ -93,6 +93,13 @@ const TextAreaStyle = sva({
         },
       },
     },
+    fullWidth: {
+      true: {
+        root: {
+          width: "100%",
+        },
+      },
+    },
   },
 });
 
@@ -103,6 +110,7 @@ type Props = {
   invalidMessage?: string;
   autoAdjustHeight?: boolean;
   requiredLabel?: string;
+  fullWidth?: boolean;
 } & ComponentPropsWithoutRef<"textarea">;
 
 export const TextArea = forwardRef<HTMLTextAreaElement, Props>(

--- a/src/components/TextField/TextField.stories.tsx
+++ b/src/components/TextField/TextField.stories.tsx
@@ -100,3 +100,9 @@ export const WithText: Story = {
     label: "URL",
   },
 };
+
+export const FullWidth: Story = {
+  args: {
+    fullWidth: true,
+  },
+};

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -5,7 +5,10 @@ import {
 import mergeRefs from "merge-refs";
 import React, { forwardRef } from "react";
 import { css, cx } from "../../../styled-system/css";
-import { textFieldRecipe } from "../../../styled-system/recipes";
+import {
+  textFieldRecipe,
+  type TextFieldRecipeVariantProps,
+} from "../../../styled-system/recipes";
 
 type Props = {
   label?: string;
@@ -15,7 +18,8 @@ type Props = {
   leftContent?: React.ReactNode;
   rightContent?: React.ReactNode;
   requiredLabel?: string;
-} & React.ComponentPropsWithoutRef<"input">;
+} & TextFieldRecipeVariantProps &
+  React.ComponentPropsWithoutRef<"input">;
 
 export const TextField = forwardRef<HTMLInputElement, Props>(
   (
@@ -40,8 +44,9 @@ export const TextField = forwardRef<HTMLInputElement, Props>(
   ) => {
     const inputRef = React.useRef<HTMLInputElement>(null);
     const mergedRef = mergeRefs(inputRef, ref);
-    const [variantProps, elementProps] =
-      textFieldRecipe.splitVariantProps(props);
+    const [variantProps, elementProps] = textFieldRecipe.splitVariantProps({
+      ...props,
+    });
     const styles = textFieldRecipe(variantProps);
     const showMessageField = description || (invalid && invalidMessage);
     const [_value, setValue] = React.useState(props.defaultValue || value);

--- a/src/recipes/textFieldRecipe.ts
+++ b/src/recipes/textFieldRecipe.ts
@@ -107,4 +107,13 @@ export const textFieldRecipe: SlotRecipeConfig = {
       color: "sd.system.color.impression.negative",
     },
   },
+  variants: {
+    fullWidth: {
+      true: {
+        root: {
+          width: "100%",
+        },
+      },
+    },
+  },
 };


### PR DESCRIPTION
TextArea:
- 新しいfullWidthプロパティを追加し、幅を100%に設定するスタイルを追加。

TextField:
- 新しいfullWidthプロパティを追加し、幅を100%に設定するスタイルを追加。
- textFieldRecipeにfullWidthバリアントを追加。