### PR TITLE
Searchコンポーネントのメニュー位置が移動するバグを修正

### DIFF
--- a/src/components/Search/Search.stories.tsx
+++ b/src/components/Search/Search.stories.tsx
@@ -3,6 +3,7 @@ import { Search } from "./Search";
 import figma from "@figma/code-connect";
 import { userEvent, within, waitFor, expect } from "@storybook/test";
 import { FullscreenLayout } from "../../../.storybook/FullscreenLayout";
+import { useState } from "react";
 
 const items = [
   "React",
@@ -107,6 +108,35 @@ export const PlayDisplayMenu: Story = {
         expect(option).toBeInTheDocument();
       },
       { timeout: 3000 }
+    );
+  },
+};
+
+export const Filtered: Story = {
+  args: {
+    disabled: false,
+    placeholder: "フレームワークを検索",
+  },
+  render: (args) => {
+    const [filteredItems, setFilteredItems] = useState(items);
+
+    const handleInputValueChange = (details: { inputValue: string }) => {
+      const value = details.inputValue.toLowerCase();
+      if (value === "") {
+        setFilteredItems(items);
+      } else {
+        setFilteredItems(
+          items.filter((item) => item.toLowerCase().includes(value))
+        );
+      }
+    };
+
+    return (
+      <Search
+        {...args}
+        items={filteredItems}
+        onInputValueChange={handleInputValueChange}
+      />
     );
   },
 };

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -191,29 +191,27 @@ export const Search: React.FC<SearchStyleProps> = ({
           </Combobox.Trigger>
         )}
       </Combobox.Control>
-      {items.length > 0 && (
-        <Portal>
-          <Combobox.Positioner>
-            <Combobox.Content className={styles.combobox}>
-              <Combobox.ItemGroup id="framework">
-                {collection.items.map((item, i) => (
-                  <Combobox.Item
-                    key={i}
-                    item={item}
-                    className={styles.comboboxItem}
-                  >
-                    <Box
-                      w="sd.system.dimension.spacing.large"
-                      h="sd.system.dimension.spacing.large"
-                    />
-                    <Combobox.ItemText>{item}</Combobox.ItemText>
-                  </Combobox.Item>
-                ))}
-              </Combobox.ItemGroup>
-            </Combobox.Content>
-          </Combobox.Positioner>
-        </Portal>
-      )}
+      <Portal>
+        <Combobox.Positioner>
+          <Combobox.Content className={styles.combobox}>
+            <Combobox.ItemGroup id="framework">
+              {collection.items.map((item, i) => (
+                <Combobox.Item
+                  key={i}
+                  item={item}
+                  className={styles.comboboxItem}
+                >
+                  <Box
+                    w="sd.system.dimension.spacing.large"
+                    h="sd.system.dimension.spacing.large"
+                  />
+                  <Combobox.ItemText>{item}</Combobox.ItemText>
+                </Combobox.Item>
+              ))}
+            </Combobox.ItemGroup>
+          </Combobox.Content>
+        </Combobox.Positioner>
+      </Portal>
     </Combobox.Root>
   );
 };


### PR DESCRIPTION
Fix #101

## 概要

Searchコンポーネントにて項目がフィルターされ0件になった際にメニューの位置が画面左上に移動してしまうバグを解消しました。

### 再現動画

https://github.com/user-attachments/assets/170645d3-c0dc-4450-a8fb-8b4ef4c234c6

## 修正点

items.lengthが0になった際の処理を Positioner などのメニュー要素の位置を取得する要素に対して行なっていたため