### PR TITLE
(WIP)Migrate publish-dev-package workflow to npm Trusted Publishing

### DIFF
--- a/.github/workflows/publish-dev-package.yml
+++ b/.github/workflows/publish-dev-package.yml
@@ -10,10 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: "npm"
@@ -33,6 +34,4 @@ jobs:
           npm version --no-git-tag-version "$NEW_VERSION"
 
       - name: Publish to npm
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --tag dev --access public
+        run: npm publish --tag dev --access public --provenance

--- a/.release-it.json
+++ b/.release-it.json
@@ -4,6 +4,9 @@
     "commitMessage": "release v${version}",
     "tagName": "${npm.name}@${version}"
   },
+  "npm": {
+    "publishArgs": ["--provenance"]
+  },
   "github": {
     "release": true,
     "releaseName": "${npm.name}@${version}",


### PR DESCRIPTION
## Summary
- npm の Trusted Publishing 機能に対応し、トークンレスでの npm publish を実現
- OIDC認証を使用することでセキュリティが向上し、NPM_TOKEN の管理が不要に

## Changes
- `id-token: write` permission を追加（OIDC認証に必要）
- `actions/setup-node` を v4 → v5 に更新（npm 11.5.1以上が必要）
- `npm publish` に `--provenance` フラグを追加
- `NPM_TOKEN` secret の使用を削除

## Required Setup (npmjs.com)
このPRをマージする前に、npmjs.com でパッケージの Trusted Publisher を設定する必要があります：

1. https://www.npmjs.com/package/@serendie/ui/access にアクセス
2. **Trusted Publisher** セクションで **Add Trusted Publisher** をクリック
3. 以下を入力：
   - **Owner**: `serendie`
   - **Repository**: `serendie`
   - **Workflow filename**: `publish-dev-package.yml`

## References
- https://docs.npmjs.com/trusted-publishers
- https://eiji.page/blog/npm-trusted-publishing/

🤖 Generated with [Claude Code](https://claude.com/claude-code)