### PR TITLE
dependabotの対象を全依存とGitHub Actionsに拡大

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,9 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
-    allow:
-      - dependency-name: "@serendie/*"
+      interval: "weekly"
+    open-pull-requests-limit: 10
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
@serendie/*のみを対象としていたallowを外し全npm依存を対象にする。
あわせてgithub-actionsエコシステムを追加し、頻度はweekly、PR上限は10に設定。