### PR TITLE
dependabotの更新をpatchのみに絞りgroupsでまとめる

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,29 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    groups:
+      npm-patches:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      actions-patches:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"


### PR DESCRIPTION
major/minorをignoreしてpatchのみを対象にし、npm・github-actions それぞれgroupsで1PRに集約する。週あたりのPR数を最小化しつつ
脆弱性PRはsecurity updates経由で引き続き受け取る運用とする。