### PR TITLE
DependabotのPRでChromaticのデプロイをスキップする

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   deploy:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- DependabotのPRでChromaticのデプロイジョブをスキップするように変更
- Dependabotはリポジトリのsecretsにアクセスできないため、`CHROMATIC_PROJECT_TOKEN`が取得できず常に失敗していた

## Test plan
- [ ] Dependabot PRでdeployジョブがスキップされることを確認
- [ ] 通常のPRではdeployジョブが実行されることを確認