### PR TITLE
Dependabotでminorアップデートも追随しグループでまとめる

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,28 +6,28 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 10
     groups:
-      npm-patches:
+      npm-minor-and-patch:
         patterns:
           - "*"
         update-types:
+          - "minor"
           - "patch"
     ignore:
       - dependency-name: "*"
         update-types:
           - "version-update:semver-major"
-          - "version-update:semver-minor"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     groups:
-      actions-patches:
+      actions-minor-and-patch:
         patterns:
           - "*"
         update-types:
+          - "minor"
           - "patch"
     ignore:
       - dependency-name: "*"
         update-types:
           - "version-update:semver-major"
-          - "version-update:semver-minor"


### PR DESCRIPTION
## Summary
- Dependabotのグループ設定をpatchのみからminor+patchに変更
- ignoreもmajorのみに変更し、minorアップデートを許可
- minorアップデートが個別PRとして来ていた問題を解消（グループにまとまるようになる）

## Test plan
- [ ] 次回のDependabot実行でminorアップデートもグループPRに含まれることを確認