### PR TITLE
eslint-plugin-react-refreshのminorアップデートをignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,9 @@ updates:
       - dependency-name: "*"
         update-types:
           - "version-update:semver-major"
+      - dependency-name: "eslint-plugin-react-refresh"
+        update-types:
+          - "version-update:semver-minor"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Summary
- `eslint-plugin-react-refresh` の minor アップデート（0.5.x）を Dependabot の ignore に追加
- 0.5.x は `eslint@^9 || ^10` を要求するため、現在の `eslint@8` 環境では `npm ci` が ERESOLVE で失敗する（PR #185）
- eslint 9 移行まではパッチアップデートのみに制限

## Test plan
- [ ] 次回 Dependabot 実行で `eslint-plugin-react-refresh` の 0.5.x が含まれないことを確認