### PR TITLE
lodashを4.18.1にoverrideして脆弱性を修正

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17064,9 +17064,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.capitalize": {
@@ -19788,13 +19788,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/release-it/node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/release-it/node_modules/log-symbols": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -157,6 +157,7 @@
     "@rollup/rollup-linux-x64-gnu": "^4.14.3"
   },
   "overrides": {
-    "axios": "1.13.2"
+    "axios": "1.13.2",
+    "lodash": "4.18.1"
   }
 }


### PR DESCRIPTION
## Summary
- lodash を 4.18.1 に npm overrides で強制更新
- nivo 等が依存する lodash 4.17.x に以下の脆弱性がある（Dependabot alert #75, #76）
  - Code Injection via `_.template` imports key names (high)
  - Prototype Pollution via array path bypass in `_.unset` and `_.omit` (medium)
- lodash 4.18.1 で修正済みだが、上流ライブラリが未更新のため overrides で対応

## Test plan
- [x] `npm run build:storybook` ビルド成功
- [x] `npm ls lodash` で全て 4.18.1 に更新されていることを確認
- [x] Storybook 上でチャートコンポーネント（nivo）が正常表示されること