### PR TITLE
borderのshorthandを使うことで意図しないborder-colorで表示される問題を修正

### DIFF
--- a/src/components/BottomNavigation/BottomNavigation.tsx
+++ b/src/components/BottomNavigation/BottomNavigation.tsx
@@ -15,7 +15,8 @@ export const BottomNavigation = ({
           justifyContent: "space-around",
           height: 64,
           paddingX: "sd.system.dimension.spacing.medium",
-          borderTop: "1px solid",
+          borderTopWidth: "1px",
+          borderTopStyle: "solid",
           borderTopColor: "sd.system.color.component.outline",
         }),
         className

--- a/src/components/DataTable/DataTable.stories.tsx
+++ b/src/components/DataTable/DataTable.stories.tsx
@@ -411,8 +411,9 @@ export const WithColumnResize: Story = {
                     cursor: "col-resize",
                     userSelect: "none",
                     touchAction: "none",
-                    borderRight: "1px solid",
-                    borderColor: "sd.system.color.component.outline",
+                    borderRightWidth: "1px",
+                    borderRightStyle: "solid",
+                    borderRightColor: "sd.system.color.component.outline",
                   })}
                 />
               </DataTable.HeaderCell>

--- a/src/components/DataTable/table/BodyCell.tsx
+++ b/src/components/DataTable/table/BodyCell.tsx
@@ -3,8 +3,9 @@ import { cva, cx, RecipeVariantProps } from "../../../../styled-system/css";
 
 const cellStyle = cva({
   base: {
-    borderBottom: "1px solid",
-    borderColor: "sd.system.color.component.outline",
+    borderBottomWidth: "1px",
+    borderBottomStyle: "solid",
+    borderBottomColor: "sd.system.color.component.outline",
     fontFamily: "Roboto, sans-serif",
     color: "sd.system.color.component.onSurface",
     textAlign: "left",

--- a/src/components/DataTable/table/HeaderCell.tsx
+++ b/src/components/DataTable/table/HeaderCell.tsx
@@ -4,8 +4,9 @@ import { css, cva, cx } from "../../../../styled-system/css";
 
 const tableHeaderCellStyle = cva({
   base: {
-    borderBottom: "1px solid",
-    borderColor: "sd.system.color.component.outline",
+    borderBottomWidth: "1px",
+    borderBottomStyle: "solid",
+    borderBottomColor: "sd.system.color.component.outline",
     fontFamily: "Roboto, sans-serif",
     color: "sd.system.color.component.onSurface",
     textAlign: "left",

--- a/src/components/DataTable/table/Root.tsx
+++ b/src/components/DataTable/table/Root.tsx
@@ -6,7 +6,8 @@ const tableRootStyles = sva({
   slots: ["container", "table"],
   base: {
     container: {
-      border: "1px solid",
+      borderWidth: "1px",
+      borderStyle: "solid",
       borderColor: "sd.system.color.component.outline",
       borderRadius: "4px",
       overflow: "hidden",

--- a/src/components/Tabs/TabItem.tsx
+++ b/src/components/Tabs/TabItem.tsx
@@ -17,7 +17,8 @@ export const TabItemStyle = sva({
       transitionDuration: ".2s",
       transitionProperty: "color, border-color",
       transitionTimingFunction: "cubic-bezier(.2, 0, 0, 1)",
-      borderBottom: "2px solid",
+      borderBottomWidth: "2px",
+      borderBottomStyle: "solid",
       borderBottomColor: "transparent",
       textStyle: "sd.system.typography.label.large_compact",
       _expanded: {


### PR DESCRIPTION
 `borderBottom: "1px solid"` と `borderColor` を別々に指定していたことで、Panda CSS の utility 生成順によって `border-bottom` shorthand が `border-bottom-color` を `currentColor` に戻してしまう問題を修正しました。


