### PR TITLE
Storybook の不安定なサンプル描画を安定化

### DIFF
--- a/src/components/DataTable/DataTable.sampleData.test.ts
+++ b/src/components/DataTable/DataTable.sampleData.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { createDataTableRows } from "./DataTable.sampleData";
+
+describe("createDataTableRows", () => {
+  it("generates stable sample rows from the default seed", () => {
+    assert.deepEqual(createDataTableRows(), createDataTableRows());
+  });
+
+  it("does not depend on global Math.random", () => {
+    const originalRandom = Math.random;
+    Math.random = () => {
+      throw new Error("Math.random must not be used for Storybook data");
+    };
+
+    try {
+      assert.equal(createDataTableRows().length, 10);
+    } finally {
+      Math.random = originalRandom;
+    }
+  });
+
+  it("generates rows that match the Storybook table format", () => {
+    const rows = createDataTableRows();
+
+    assert.equal(rows.length, 10);
+
+    rows.forEach((row, index) => {
+      assert.equal(row.id, index + 1);
+      assert.match(row.time, /^2025-04-\d{2} \d{2}:\d{2}$/);
+      assert.match(row.coverage, /^\d+%$/);
+      assert.match(row.errorRate, /^\d+\.\d{2}%$/);
+      assert.ok(row.connections >= 50 && row.connections <= 5000);
+      assert.ok(row.households >= 30 && row.households <= 4000);
+    });
+  });
+});

--- a/src/components/DataTable/DataTable.sampleData.ts
+++ b/src/components/DataTable/DataTable.sampleData.ts
@@ -1,0 +1,82 @@
+export type DataRow = {
+  id: number;
+  area: string;
+  time: string;
+  status: string;
+  connections: number;
+  households: number;
+  coverage: string;
+  errorRate: string;
+  process: string;
+};
+
+const areaList = [
+  "東京",
+  "大阪",
+  "名古屋",
+  "札幌",
+  "福岡",
+  "仙台",
+  "広島",
+  "神戸",
+  "京都",
+  "横浜",
+];
+const statusList = ["正常", "警告", "障害", "調査中"];
+const processList = ["完了", "進行中", "未着手", "一時停止"];
+
+const DEFAULT_SEED = 0x5e2e_7d15;
+
+function createSeededRandom(seed: number) {
+  let value = seed;
+
+  return () => {
+    value |= 0;
+    value = (value + 0x6d2b_79f5) | 0;
+
+    let result = Math.imul(value ^ (value >>> 15), 1 | value);
+    result =
+      (result + Math.imul(result ^ (result >>> 7), 61 | result)) ^ result;
+
+    return ((result ^ (result >>> 14)) >>> 0) / 4_294_967_296;
+  };
+}
+
+function randomInt(random: () => number, min: number, max: number) {
+  return Math.floor(random() * (max - min + 1)) + min;
+}
+
+function randomPick<T>(random: () => number, arr: T[]): T {
+  return arr[randomInt(random, 0, arr.length - 1)];
+}
+
+export function createDataTableRows(seed = DEFAULT_SEED): DataRow[] {
+  const random = createSeededRandom(seed);
+
+  return Array.from({ length: 10 }, (_, i) => {
+    const area = randomPick(random, areaList);
+    const status = randomPick(random, statusList);
+    const process = randomPick(random, processList);
+    const connections = randomInt(random, 50, 5000);
+    const households = randomInt(random, 30, 4000);
+    const coverage = `${randomInt(random, 60, 100)}%`;
+    const errorRate = `${(random() * 5).toFixed(2)}%`;
+    const hour = randomInt(random, 0, 23).toString().padStart(2, "0");
+    const minute = randomInt(random, 0, 59).toString().padStart(2, "0");
+    const time = `2025-04-${randomInt(random, 1, 30)
+      .toString()
+      .padStart(2, "0")} ${hour}:${minute}`;
+
+    return {
+      id: i + 1,
+      area,
+      time,
+      status,
+      connections,
+      households,
+      coverage,
+      errorRate,
+      process,
+    };
+  });
+}

--- a/src/components/DataTable/DataTable.stories.tsx
+++ b/src/components/DataTable/DataTable.stories.tsx
@@ -8,6 +8,7 @@ import {
 } from "@tanstack/react-table";
 import { css } from "../../../styled-system/css";
 import { DataTable } from ".";
+import { createDataTableRows, type DataRow } from "./DataTable.sampleData";
 
 export const FigmaExample = () => {
   type DataRowType = {
@@ -108,66 +109,7 @@ export default meta;
 
 type Story = StoryObj<typeof DataTable>;
 
-export type DataRow = {
-  id: number;
-  area: string;
-  time: string;
-  status: string;
-  connections: number;
-  households: number;
-  coverage: string;
-  errorRate: string;
-  process: string;
-};
-
-const areaList = [
-  "東京",
-  "大阪",
-  "名古屋",
-  "札幌",
-  "福岡",
-  "仙台",
-  "広島",
-  "神戸",
-  "京都",
-  "横浜",
-];
-const statusList = ["正常", "警告", "障害", "調査中"];
-const processList = ["完了", "進行中", "未着手", "一時停止"];
-
-function randomInt(min: number, max: number) {
-  return Math.floor(Math.random() * (max - min + 1)) + min;
-}
-
-function randomPick<T>(arr: T[]): T {
-  return arr[randomInt(0, arr.length - 1)];
-}
-
-const Data: DataRow[] = Array.from({ length: 10 }, (_, i) => {
-  const area = randomPick(areaList);
-  const status = randomPick(statusList);
-  const process = randomPick(processList);
-  const connections = randomInt(50, 5000);
-  const households = randomInt(30, 4000);
-  const coverage = `${randomInt(60, 100)}%`;
-  const errorRate = `${(Math.random() * 5).toFixed(2)}%`;
-  const hour = randomInt(0, 23).toString().padStart(2, "0");
-  const minute = randomInt(0, 59).toString().padStart(2, "0");
-  const time = `2025-04-${randomInt(1, 30)
-    .toString()
-    .padStart(2, "0")} ${hour}:${minute}`;
-  return {
-    id: i + 1,
-    area,
-    time,
-    status,
-    connections,
-    households,
-    coverage,
-    errorRate,
-    process,
-  };
-});
+const Data: DataRow[] = createDataTableRows();
 
 const columnHelper = DataTable.createColumnHelper<DataRow>();
 

--- a/src/components/DatePicker/DatePicker.stories.tsx
+++ b/src/components/DatePicker/DatePicker.stories.tsx
@@ -131,5 +131,6 @@ export const ControlledRange: Story = {
 export const CalendarOnly: Story = {
   args: {
     isCalendarOnly: true,
+    value: [parseDate("2025-01-01")],
   },
 };

--- a/src/components/ProgressIndicator/AnimatedArc.test.ts
+++ b/src/components/ProgressIndicator/AnimatedArc.test.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { getAnimatedArcProps } from "./animatedArcProps";
+
+describe("getAnimatedArcProps", () => {
+  it("returns stable SVG props for the same animation progress", () => {
+    assert.deepEqual(
+      getAnimatedArcProps({ progress: 0.25, radius: 8, width: 6 }),
+      getAnimatedArcProps({ progress: 0.25, radius: 8, width: 6 })
+    );
+  });
+
+  it("normalizes progress into a single animation loop", () => {
+    assert.deepEqual(
+      getAnimatedArcProps({ progress: 0.25, radius: 8, width: 6 }),
+      getAnimatedArcProps({ progress: 1.25, radius: 8, width: 6 })
+    );
+  });
+});

--- a/src/components/ProgressIndicator/AnimatedArc.tsx
+++ b/src/components/ProgressIndicator/AnimatedArc.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { describeArc } from "./util";
+import { getAnimatedArcProps } from "./animatedArcProps";
 
 const SECONDS_PER_LOOP = 2.5; // 1周あたりの秒数（30fps換算で75フレーム）
 
@@ -7,13 +7,18 @@ export const AnimatedArc: React.FC<{
   className?: string;
   radius: number;
   width: number; // strokeWidth
-}> = ({ className, radius, width }) => {
-  const [t, setT] = React.useState(0); // 0〜1 で 1 周
+  progress?: number;
+}> = ({ className, radius, width, progress }) => {
+  const [uncontrolledProgress, setUncontrolledProgress] = React.useState(0);
   const previousFrameTimeRef = React.useRef<number | null>(null);
   const rafIdRef = React.useRef<number | null>(null);
 
   // アニメーションループ
   React.useEffect(() => {
+    if (progress != null) {
+      return;
+    }
+
     const frame = (now: number) => {
       if (previousFrameTimeRef.current == null) {
         previousFrameTimeRef.current = now;
@@ -21,29 +26,25 @@ export const AnimatedArc: React.FC<{
       const deltaSeconds = (now - previousFrameTimeRef.current) / 1000;
       previousFrameTimeRef.current = now;
       const deltaT = deltaSeconds / SECONDS_PER_LOOP;
-      setT((prev) => (prev + deltaT) % 1);
+      setUncontrolledProgress((prev) => (prev + deltaT) % 1);
       rafIdRef.current = requestAnimationFrame(frame);
     };
     rafIdRef.current = requestAnimationFrame(frame);
     return () => {
       if (rafIdRef.current != null) cancelAnimationFrame(rafIdRef.current);
     };
-  }, []);
+  }, [progress]);
 
   // 弧の「開始角」「長さ」を計算
-  const { d, rotationDeg } = React.useMemo(() => {
-    const theta = t * Math.PI * 2;
-    const end = 180 + 40 * Math.sin(-theta) + 40;
-    const start = 90 * Math.sin(theta) + 90;
-    const dPath = describeArc(
-      radius + width, // cx
-      radius + width, // cy
-      radius, // r
-      t * 360 + start,
-      t * 360 + end
-    );
-    return { d: dPath, rotationDeg: t * 360 };
-  }, [t, radius, width]);
+  const { d, rotationDeg } = React.useMemo(
+    () =>
+      getAnimatedArcProps({
+        progress: progress ?? uncontrolledProgress,
+        radius,
+        width,
+      }),
+    [progress, uncontrolledProgress, radius, width]
+  );
 
   return (
     <path

--- a/src/components/ProgressIndicator/ProgressIndicator.stories.tsx
+++ b/src/components/ProgressIndicator/ProgressIndicator.stories.tsx
@@ -34,6 +34,10 @@ const meta: Meta<typeof ProgressIndicator> = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+const fixedIndeterminateFrame = {
+  animationProgress: 0.5,
+} as const;
+
 export const Linear: Story = {
   args: {
     type: "linear",
@@ -133,8 +137,16 @@ export const IndeterminateExamples: Story = {
       <div>
         <h3 style={{ marginBottom: "8px" }}>Linear Indeterminate</h3>
         <div style={{ display: "flex", flexDirection: "column", gap: "16px" }}>
-          <ProgressIndicatorIndeterminate type="linear" size="medium" />
-          <ProgressIndicatorIndeterminate type="linear" size="large" />
+          <ProgressIndicatorIndeterminate
+            type="linear"
+            size="medium"
+            {...fixedIndeterminateFrame}
+          />
+          <ProgressIndicatorIndeterminate
+            type="linear"
+            size="large"
+            {...fixedIndeterminateFrame}
+          />
         </div>
       </div>
       <div>
@@ -144,16 +156,19 @@ export const IndeterminateExamples: Story = {
             type="circular"
             size="small"
             color="primary"
+            {...fixedIndeterminateFrame}
           />
           <ProgressIndicatorIndeterminate
             type="circular"
             size="medium"
             color="primary"
+            {...fixedIndeterminateFrame}
           />
           <ProgressIndicatorIndeterminate
             type="circular"
             size="large"
             color="primary"
+            {...fixedIndeterminateFrame}
           />
         </div>
       </div>
@@ -164,16 +179,19 @@ export const IndeterminateExamples: Story = {
             type="circular"
             size="small"
             color="subtle"
+            {...fixedIndeterminateFrame}
           />
           <ProgressIndicatorIndeterminate
             type="circular"
             size="medium"
             color="subtle"
+            {...fixedIndeterminateFrame}
           />
           <ProgressIndicatorIndeterminate
             type="circular"
             size="large"
             color="subtle"
+            {...fixedIndeterminateFrame}
           />
         </div>
       </div>

--- a/src/components/ProgressIndicator/ProgressIndicatorIndeterminate.tsx
+++ b/src/components/ProgressIndicator/ProgressIndicatorIndeterminate.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { cva, cx } from "../../../styled-system/css";
 import { AnimatedArc } from "./AnimatedArc";
+import { normalizeProgress } from "./animatedArcProps";
 
 const progressIndicatorIndeterminateStyles = cva({
   base: {
@@ -151,6 +152,7 @@ export interface ProgressIndicatorIndeterminateProps extends React.ComponentProp
   type?: "linear" | "circular";
   size?: "small" | "medium" | "large";
   color?: "primary" | "subtle";
+  animationProgress?: number;
 }
 
 const getCircleProps = (size: "small" | "medium" | "large") => {
@@ -175,10 +177,16 @@ export const ProgressIndicatorIndeterminate = ({
   type = "linear",
   size = "medium",
   color = "primary",
+  animationProgress,
   className,
   style,
   ...props
 }: ProgressIndicatorIndeterminateProps) => {
+  const normalizedAnimationProgress =
+    animationProgress == null
+      ? undefined
+      : normalizeProgress(animationProgress);
+
   if (type === "circular") {
     const { radius, strokeWidth } = getCircleProps(size);
 
@@ -200,6 +208,7 @@ export const ProgressIndicatorIndeterminate = ({
             className={filledStyles({ type, size, color })}
             radius={radius}
             width={strokeWidth}
+            progress={normalizedAnimationProgress}
           />
         </svg>
       </div>
@@ -218,7 +227,19 @@ export const ProgressIndicatorIndeterminate = ({
       {...props}
     >
       <div className={trackStyles({ type, size })} />
-      <div className={filledStyles({ type, size, color })} />
+      <div
+        className={filledStyles({ type, size, color })}
+        style={
+          normalizedAnimationProgress == null
+            ? undefined
+            : {
+                animation: "none",
+                transform: `translateX(${
+                  normalizedAnimationProgress * 300 - 150
+                }%)`,
+              }
+        }
+      />
     </div>
   );
 };

--- a/src/components/ProgressIndicator/animatedArcProps.ts
+++ b/src/components/ProgressIndicator/animatedArcProps.ts
@@ -1,0 +1,31 @@
+import { describeArc } from "./util";
+
+type AnimatedArcProps = {
+  progress: number;
+  radius: number;
+  width: number;
+};
+
+export const normalizeProgress = (progress: number) => {
+  return ((progress % 1) + 1) % 1;
+};
+
+export const getAnimatedArcProps = ({
+  progress,
+  radius,
+  width,
+}: AnimatedArcProps) => {
+  const t = normalizeProgress(progress);
+  const theta = t * Math.PI * 2;
+  const end = 180 + 40 * Math.sin(-theta) + 40;
+  const start = 90 * Math.sin(theta) + 90;
+  const d = describeArc(
+    radius + width,
+    radius + width,
+    radius,
+    t * 360 + start,
+    t * 360 + end
+  );
+
+  return { d, rotationDeg: t * 360 };
+};


### PR DESCRIPTION
## 概要
- DataTable の Storybook サンプル行生成を、毎回変わる `Math.random()` から固定 seed の生成に変更しました。
- DatePicker の `CalendarOnly` story に固定日付を渡し、実行日の影響を受けないようにしました。
- ProgressIndicator の indeterminate 表示に固定フレーム用の `animationProgress` を追加し、Storybook では同じ瞬間を描画するようにしました。
- DataTable と ProgressIndicator の安定化ロジックをテストで固定しました。

## 背景
Chromatic の visual snapshot は、乱数・現在日付・実行時アニメーションの影響を受けると毎回差分が出ます。

今回の対象では、DataTable は `Math.random()`、DatePicker は未指定時の現在日付、ProgressIndicator は `requestAnimationFrame` と CSS animation による indeterminate 表示が不安定要因でした。

## 確認
- `node --import tsx --test src/components/ProgressIndicator/AnimatedArc.test.ts src/components/DataTable/DataTable.sampleData.test.ts`
- `npx eslint src/components/DatePicker/DatePicker.stories.tsx src/components/ProgressIndicator/AnimatedArc.tsx src/components/ProgressIndicator/AnimatedArc.test.ts src/components/ProgressIndicator/animatedArcProps.ts src/components/ProgressIndicator/ProgressIndicatorIndeterminate.tsx src/components/ProgressIndicator/ProgressIndicator.stories.tsx --quiet`
- `npm run build:storybook`

補足: `npm run build:storybook` は成功していますが、既存の別コンポーネント由来の declaration generation 型エラーはログに出ています。