### PR TITLE
Add Footer component with app and website variants

### DIFF
--- a/src/components/Footer/Footer.stories.tsx
+++ b/src/components/Footer/Footer.stories.tsx
@@ -1,0 +1,120 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import figma from "@figma/code-connect";
+import { Footer } from "./Footer";
+
+// Generic placeholder standing in for a brand logo in the examples.
+const LogoPlaceholder = () => (
+  <svg
+    width="96"
+    height="24"
+    viewBox="0 0 96 24"
+    role="img"
+    aria-label="Logo"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <rect width="96" height="24" rx="4" fill="#d1d0cd" />
+    <text
+      x="48"
+      y="16"
+      textAnchor="middle"
+      fontFamily="sans-serif"
+      fontSize="11"
+      fill="#000000"
+    >
+      LOGO
+    </text>
+  </svg>
+);
+
+const sampleLinks = [
+  { label: "Privacy Policy", href: "#" },
+  { label: "Terms of Use", href: "#" },
+  { label: "Cookie Policy", href: "#" },
+];
+
+const sampleCopyright = "© 2026 Example, Inc. All rights reserved.";
+
+function FigmaExampleApp() {
+  return (
+    <Footer
+      type="app"
+      copyright={sampleCopyright}
+      links={sampleLinks}
+      logo={<LogoPlaceholder />}
+    />
+  );
+}
+
+function FigmaExampleWebsite() {
+  return <Footer type="website" copyright={sampleCopyright} />;
+}
+
+const meta: Meta<typeof Footer> = {
+  component: Footer,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Page footer with two variants: `app` shows the copyright at the start with trailing links and an optional logo, while `website` shows a centered copyright only.",
+      },
+    },
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/CvzXFVVdFq17ZpenRXfZ2I/Serendie-Design-System--Community-?node-id=1-12666",
+      props: {
+        type: figma.enum("Type", {
+          Default: "app",
+          "Copyright only": "website",
+        }),
+      },
+      examples: [
+        {
+          example: FigmaExampleApp,
+          variant: { Type: "Default" },
+        },
+        {
+          example: FigmaExampleWebsite,
+          variant: { Type: "Copyright only" },
+        },
+      ],
+    },
+    controls: {
+      expanded: true,
+    },
+  },
+};
+
+type Story = StoryObj<typeof Footer>;
+export default meta;
+
+export const App: Story = {
+  args: {
+    type: "app",
+    copyright: sampleCopyright,
+    links: sampleLinks,
+    logo: <LogoPlaceholder />,
+  },
+  render: (args) => <Footer {...args} />,
+};
+
+export const Website: Story = {
+  args: {
+    type: "website",
+    copyright: sampleCopyright,
+  },
+  render: (args) => <Footer {...args} />,
+};
+
+export const All: Story = {
+  render: () => (
+    <div style={{ display: "flex", flexDirection: "column", gap: "48px" }}>
+      <Footer
+        type="app"
+        copyright={sampleCopyright}
+        links={sampleLinks}
+        logo={<LogoPlaceholder />}
+      />
+      <Footer type="website" copyright={sampleCopyright} />
+    </div>
+  ),
+};

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,0 +1,115 @@
+import { ComponentProps } from "react";
+import { RecipeVariantProps, cx, sva } from "../../../styled-system/css";
+
+const footerStyle = sva({
+  slots: ["root", "copyright", "row", "link", "logo"],
+  base: {
+    root: {
+      width: "100%",
+      display: "flex",
+      alignItems: "center",
+      paddingBlock: "sd.system.dimension.spacing.small",
+      borderTopWidth: "sd.system.dimension.border.medium",
+      borderTopStyle: "solid",
+      borderTopColor: "sd.system.color.component.outline",
+    },
+    copyright: {
+      textStyle: "sd.system.typography.label.large_compact",
+      color: "sd.system.color.component.onSurface",
+      wordBreak: "break-word",
+    },
+    row: {
+      display: "flex",
+      alignItems: "center",
+      gap: "sd.system.dimension.spacing.extraLarge",
+    },
+    link: {
+      textStyle: "sd.system.typography.label.large_compact",
+      color: "sd.system.color.component.onSurface",
+      textDecoration: "none",
+      cursor: "pointer",
+      whiteSpace: "nowrap",
+      _hover: {
+        textDecoration: "underline",
+      },
+    },
+    logo: {
+      display: "flex",
+      alignItems: "center",
+      flexShrink: 0,
+      height: "24px",
+      "& > *": {
+        maxHeight: "100%",
+        width: "auto",
+      },
+    },
+  },
+  variants: {
+    type: {
+      app: {
+        root: {
+          justifyContent: "space-between",
+        },
+      },
+      website: {
+        root: {
+          justifyContent: "center",
+        },
+      },
+    },
+  },
+  defaultVariants: {
+    type: "app",
+  },
+});
+
+type VariantProps = RecipeVariantProps<typeof footerStyle>;
+
+export type FooterLink = {
+  label: string;
+  href?: string;
+  onClick?: React.MouseEventHandler<HTMLAnchorElement>;
+};
+
+export type FooterProps = {
+  /** Copyright text or node shown at the start (app) / center (website). */
+  copyright: React.ReactNode;
+  /** Link items rendered on the trailing side. Only rendered for `type="app"`. */
+  links?: FooterLink[];
+  /** Logo slot rendered after the links; any image/SVG is capped at 24px height. Only rendered for `type="app"`. */
+  logo?: React.ReactNode;
+} & VariantProps &
+  Omit<ComponentProps<"footer">, "children">;
+
+export const Footer: React.FC<FooterProps> = ({
+  copyright,
+  links,
+  logo,
+  ...props
+}) => {
+  const [variantProps, { className, ...elementProps }] =
+    footerStyle.splitVariantProps(props);
+  const styles = footerStyle(variantProps);
+  const isWebsite = variantProps.type === "website";
+
+  return (
+    <footer className={cx(styles.root, className)} {...elementProps}>
+      <p className={styles.copyright}>{copyright}</p>
+      {!isWebsite && (links?.length || logo) && (
+        <div className={styles.row}>
+          {links?.map((link, index) => (
+            <a
+              key={`${link.label}-${index}`}
+              className={styles.link}
+              href={link.href}
+              onClick={link.onClick}
+            >
+              {link.label}
+            </a>
+          ))}
+          {logo && <span className={styles.logo}>{logo}</span>}
+        </div>
+      )}
+    </footer>
+  );
+};

--- a/src/components/Footer/index.ts
+++ b/src/components/Footer/index.ts
@@ -1,0 +1,1 @@
+export * from "./Footer.tsx";

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,7 @@ export * from "./components/DatePicker/index.ts";
 export * from "./components/Divider/index.ts";
 export * from "./components/Drawer/index.ts";
 export * from "./components/DropdownMenu/index.ts";
+export * from "./components/Footer/index.ts";
 export * from "./components/IconButton/index.ts";
 export * from "./components/List/index.ts";
 export * from "./components/ModalDialog/index.ts";


### PR DESCRIPTION
## 概要 / Overview

Figma デザイン（node `1-12666`）に基づき、`Footer` コンポーネントを追加します。
Adds a `Footer` component based on the Figma design (node `1-12666`), with two variants:

- **`app`** — 著作権表示を先頭に、末尾にリンク群と任意のロゴを配置 / copyright at the start, trailing links + optional logo
- **`website`** — 著作権表示を中央に配置（リンク・ロゴなし） / centered copyright only

## API

| Prop | Type | 説明 / Description |
| --- | --- | --- |
| `type` | `"app" \| "website"` | バリアント / variant（default: `app`） |
| `copyright` | `React.ReactNode` | 著作権表示（必須） / copyright content (required) |
| `links` | `FooterLink[]` | 末尾のリンク / trailing links（`app` のみ） |
| `logo` | `React.ReactNode` | ロゴスロット、高さ 24px にクランプ / logo slot, capped at 24px height（`app` のみ） |

`FooterLink = { label: string; href?: string; onClick?: ... }`

## 変更内容 / Key Changes

- `Footer` / `FooterLink` / `FooterProps` を追加し、`src/index.ts` から公開
- `sd.system.*` セマンティックトークンのみ使用（ライト / ダークテーマ対応）
- `App` / `Website` / `All` の Storybook ストーリーを追加
- Figma Code Connect（`parameters.design`）を設定
- Uses only `sd.system.*` semantic tokens (light/dark aware); Storybook stories + Figma Code Connect included

## 備考 / Notes

新規コンポーネントのため、プロパティ（props）や対応範囲についてご要望があれば調整します。
New component — happy to adjust the props or scope per maintainer preference.
