### PR TITLE
expandedの名前衝突（breakpointとaria-expanded状態）を解消

### DIFF
--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -107,7 +107,7 @@ export const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
             className={cx(
               textFieldStyles.inputWrapper,
               css({
-                _expanded: {
+                _ariaExpanded: {
                   outlineWidth: "sd.system.dimension.border.thick",
                   outlineColor: "sd.system.color.impression.primary",
                 },

--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -37,21 +37,9 @@ export const DropdownMenuStyle = sva({
       paddingRight: "sd.system.dimension.spacing.small",
       color: "sd.system.color.component.onSurfaceVariant",
       gap: "sd.system.dimension.spacing.extraSmall",
-      // NOTE: breakpoint の `expanded` が状態condition `_expanded`（aria-expanded）と
-      // 名前衝突しているため、`expanded:` / `_expanded` を使うとメニューを開いた時に
-      // もレスポンシブタイポグラフィが適用され文字サイズが変わってしまう。衝突を避け
-      // るため生の media query と属性セレクタで指定し、開閉状態に依らずサイズを一定に
-      // 保つ。
       textStyle: "sd.system.typography.label.large_compact",
-      "@media screen and (min-width: 48rem)": {
+      _expanded: {
         textStyle: "sd.system.typography.label.large_expanded",
-      },
-      // メニューを開いた（aria-expanded）状態でも閉じた状態と同じサイズにする
-      "&[data-part='trigger'][aria-expanded='true']": {
-        textStyle: "sd.system.typography.label.large_compact",
-        "@media screen and (min-width: 48rem)": {
-          textStyle: "sd.system.typography.label.large_expanded",
-        },
       },
       _disabled: {
         outline: "solid",
@@ -59,7 +47,7 @@ export const DropdownMenuStyle = sva({
         outlineColor: "sd.system.color.component.outline",
         outlineWidth: "sd.system.dimension.border.medium",
       },
-      _expanded: {
+      _ariaExpanded: {
         // Note: leftIcon が _open を受け取れないため button 側で制御
         "& svg": {
           transform: "rotate(180deg)",

--- a/src/preset.ts
+++ b/src/preset.ts
@@ -12,6 +12,13 @@ export const themeNames = Object.keys(themes);
 
 export const SerendiePreset = {
   name: "serendie",
+  conditions: {
+    extend: {
+      expanded: `@media screen and (min-width: ${sd.system.dimension.breakpoint.expanded})`,
+      ariaExpanded:
+        "&:is([aria-expanded=true], [data-expanded], [data-state=expanded])",
+    },
+  },
   theme: {
     extend: {
       breakpoints: {


### PR DESCRIPTION
## Summary

Issue #234 の対応。`expanded` という名前が **breakpoint（画面幅≥768px）** と **Panda CSSビルトインの状態condition（aria-expanded）** の2つで衝突していた問題を解消する。

衝突の結果、`_expanded` がmedia queryではなく `[aria-expanded=true]` 等のセレクタにコンパイルされ、**レスポンシブタイポグラフィが広範に意図通り効いていなかった**（PR #232 のDropdownMenuで開閉時に文字サイズが変わる事象として顕在化）。

### 生成CSSの変化（`_expanded`）
```diff
- .expanded\:textStyle...:is([aria-expanded=true],[data-expanded],[data-state=expanded]) { font-size:14px }
+ @media screen and (min-width: 48rem){ .expanded\:textStyle... { font-size:14px } }
```

### 修正内容
`src/preset.ts` の `conditions.extend` で名前を分離:
```ts
conditions: {
  extend: {
    expanded: `@media screen and (min-width: ${sd.system.dimension.breakpoint.expanded})`,
    ariaExpanded:
      "&:is([aria-expanded=true], [data-expanded], [data-state=expanded])",
  },
},
```
- `_expanded` / `expanded:` → media query（画面幅）に固定
- 状態用途には `_ariaExpanded` を新設

これにより、`_expanded: { textStyle }` を使う全コンポーネント（Accordion / Tabs / Toast / Breadcrumbs / ListItem / RadioButton / CheckBox / Switch / Pagination / DashboardWidget / TopAppBar / NotificationBadge など）のレスポンシブタイポが、≥768pxで正しく適用されるようになる。

真に aria-expanded 状態を意図していた2箇所のみ `_ariaExpanded` に移行:
- DropdownMenu のチェブロン回転（開いた時に180deg）
- DatePicker の開閉時 outline

あわせて PR #232 で入れた `expanded` 衝突回避の生media query + 属性セレクタのワークアラウンドを、通常のcondition記法（`_expanded` / `_ariaExpanded`）にクリーンアップした。

### 影響範囲・確認事項
`expanded:` / `_expanded` を使う全コンポーネントのレスポンシブタイポが「初めて正しく」効くため、**Chromaticに広範な視覚差分が出る見込み**。この差分でスコープと作業量を見積もる方針（Issue #234 での相談結果）。差分内容はデザイナー / nagayamaさんに確認予定。

関連: #234, #232

Link to Devin session: https://app.devin.ai/sessions/7130a2e0c61444aaa8aadfb413262939
Requested by: @shibata-hiroyoshi