### PR TITLE
publish-code-connectのNode.jsを22に上げてnpm@latest非互換を解消

### DIFF
--- a/.github/workflows/publish-code-connect.yml
+++ b/.github/workflows/publish-code-connect.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22"
 
       - name: Set NPM version
         run: npm install -g npm@latest


### PR DESCRIPTION
## Summary

Issue #240 の対応。`publish-code-connect` ワークフローが、Node 20 上で `npm install -g npm@latest` を実行する箇所で失敗する問題を解消する。

最近リリースされた `npm@12.0.1` が Node `^22.22.2 || ^24.15.0 || >=26.0.0` を要求するようになり、Node 20 と非互換で落ちていた（PR #238 の Approve 後に走った `publish-code-connect` の失敗として顕在化）。本PRの変更内容とは無関係の外部要因。

```diff
       - name: Install Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22"
```

`node-version` を `22` に上げることで `npm@latest` の Node 要件を満たす。他ワークフロー（`sync-figma-locales.yml` / `push-figma-locales.yml` が node 22、`package.yml` が node 24）とも整合する最小変更。

関連: #240, #238

Link to Devin session: https://app.devin.ai/sessions/7130a2e0c61444aaa8aadfb413262939
Requested by: @shibata-hiroyoshi