### PR TITLE
Searchの再選択不具合を修正し、labelプロパティを追加

### DIFF
--- a/src/components/Search/Search.stories.tsx
+++ b/src/components/Search/Search.stories.tsx
@@ -130,6 +130,20 @@ export const PlayDisplayMenu: Story = {
       { timeout: 3000 }
     );
 
+    const clearButton = canvas.getByRole("button", { name: /clear/i });
+    await expect(clearButton).toBeVisible();
+    await userEvent.click(clearButton);
+    await expect(input).toHaveValue("");
+
+    await userEvent.type(input, "a");
+    await waitFor(
+      async () => {
+        const option = await root.findByText("Angular");
+        expect(option).toBeInTheDocument();
+      },
+      { timeout: 3000 }
+    );
+
     await userEvent.click(root.getByRole("option", { name: "Angular" }));
     expect(args.onSearch).toHaveBeenCalledTimes(1);
 

--- a/src/components/Search/Search.stories.tsx
+++ b/src/components/Search/Search.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { Search } from "./Search";
 import figma from "@figma/code-connect";
-import { userEvent, within, waitFor, expect } from "storybook/test";
+import { fn, userEvent, within, waitFor, expect } from "storybook/test";
 import { FullscreenLayout } from "../../../.storybook/FullscreenLayout";
 
 const items = [
@@ -80,6 +80,7 @@ export const PlayDisplayMenu: Story = {
   },
   args: {
     onInputValueChange: (v) => console.log(v),
+    onSearch: fn(),
     disabled: false,
     placeholder: "デバイスIDなどを検索",
     items,
@@ -91,7 +92,7 @@ export const PlayDisplayMenu: Story = {
       </FullscreenLayout>
     );
   },
-  play: async ({ canvasElement }) => {
+  play: async ({ canvasElement, args }) => {
     const canvas = within(canvasElement);
     const parentElement = canvasElement.parentElement;
     if (!parentElement) return;
@@ -108,6 +109,17 @@ export const PlayDisplayMenu: Story = {
       },
       { timeout: 3000 }
     );
+
+    await userEvent.click(root.getByRole("option", { name: "Angular" }));
+    expect(args.onSearch).toHaveBeenCalledTimes(1);
+
+    await userEvent.click(canvas.getByRole("button", { name: /clear/i }));
+    await expect(input).toHaveValue("");
+
+    await userEvent.type(input, "Angular");
+    const option = await root.findByRole("option", { name: "Angular" });
+    await userEvent.click(option);
+    expect(args.onSearch).toHaveBeenCalledTimes(2);
   },
 };
 

--- a/src/components/Search/Search.stories.tsx
+++ b/src/components/Search/Search.stories.tsx
@@ -65,6 +65,26 @@ export const Small: Story = {
   },
 };
 
+export const WithLabel: Story = {
+  args: {
+    disabled: false,
+    label: "フレームワーク",
+    placeholder: "フレームワークを検索",
+    required: true,
+    items,
+  },
+};
+
+export const Invalid: Story = {
+  args: {
+    disabled: false,
+    invalid: true,
+    invalidMessage: "フレームワークを選択してください",
+    placeholder: "フレームワークを検索",
+    items,
+  },
+};
+
 export const Disabled: Story = {
   args: {
     onInputValueChange: (v) => console.log(v),

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -10,9 +10,10 @@ import {
   SerendieSymbolMagnifyingGlass,
   SerendieSymbolClose,
 } from "@serendie/symbols";
-import { cx, RecipeVariantProps, sva } from "../../../styled-system/css";
+import { css, cx, RecipeVariantProps, sva } from "../../../styled-system/css";
 import { Box } from "../../../styled-system/jsx";
 import { useAutoPortalContainer } from "../../hooks/useAutoPortalContainer";
+import { useTranslations } from "../../i18n";
 
 /*
  * 検索候補を出すことができるサーチコンボボックス
@@ -23,6 +24,7 @@ import { useAutoPortalContainer } from "../../hooks/useAutoPortalContainer";
 
 export const SearchStyle = sva({
   slots: [
+    "root",
     "input",
     "control",
     "combobox",
@@ -32,12 +34,16 @@ export const SearchStyle = sva({
     "clearTrigger",
   ],
   base: {
-    control: {
+    root: {
       display: "inline-grid",
       // 後から指定したCSSからwidthが上書きできないため、@layer componentsを指定
       "@layer components": {
         width: "min(100%, 300px)",
       },
+      rowGap: "sd.system.dimension.spacing.extraSmall",
+    },
+    control: {
+      width: "100%",
       lineHeight: "1",
       gridTemplateColumns: "auto 1fr auto",
       alignItems: "center",
@@ -49,6 +55,9 @@ export const SearchStyle = sva({
       _focus: {
         outlineWidth: "sd.system.dimension.border.thick",
         outlineColor: "sd.system.color.impression.primary",
+      },
+      _invalid: {
+        outlineColor: "sd.system.color.impression.negative",
       },
       _disabled: {
         bgColor: "sd.system.color.interaction.disabled",
@@ -155,6 +164,11 @@ export const SearchStyle = sva({
 type SearchStyleProps = ComboboxRootProps<string> &
   RecipeVariantProps<typeof SearchStyle> & {
     items?: string[];
+    label?: string;
+    required?: boolean;
+    requiredLabel?: string;
+    invalid?: boolean;
+    invalidMessage?: string;
     /**
      * Portalを使用するかどうか
      * - `true` (デフォルト): body直下にポータルする。ModalDialog/Drawer内にある場合は自動的にそのコンテンツ内にポータルされる
@@ -175,6 +189,12 @@ type SearchStyleProps = ComboboxRootProps<string> &
 
 export const Search: React.FC<SearchStyleProps> = ({
   items = [],
+  label,
+  required,
+  requiredLabel,
+  invalid,
+  invalidMessage,
+  className,
   portalled = true,
   allowCustomValue = true,
   onSearch,
@@ -184,6 +204,7 @@ export const Search: React.FC<SearchStyleProps> = ({
   const styles = SearchStyle(variantProps);
   const { collection: _, ...elementProps } = comboboxProps;
   const { triggerRef, portalContainerRef } = useAutoPortalContainer(portalled);
+  const t = useTranslations();
 
   // controlled / uncontrolled の判定
   const isControlled = elementProps.inputValue !== undefined;
@@ -252,6 +273,8 @@ export const Search: React.FC<SearchStyleProps> = ({
     <Combobox.Root
       {...elementProps}
       collection={collection}
+      invalid={invalid}
+      className={cx(styles.root, className)}
       openOnClick
       allowCustomValue={allowCustomValue}
       onInputValueChange={handleInputValueChange}
@@ -266,10 +289,30 @@ export const Search: React.FC<SearchStyleProps> = ({
         },
       }}
     >
-      <Combobox.Control
-        className={cx(styles.control, elementProps.className)}
-        ref={triggerRef}
-      >
+      {label && variantProps.size != "small" && (
+        // smallの場合はラベルを表示しない
+        <Combobox.Label
+          className={css({
+            textStyle: {
+              base: "sd.system.typography.label.medium_compact",
+              expanded: "sd.system.typography.label.medium_expanded",
+            },
+          })}
+        >
+          {label}
+          {required && (
+            <span
+              className={css({
+                pl: "sd.system.dimension.spacing.extraSmall",
+                color: "sd.system.color.impression.negative",
+              })}
+            >
+              {requiredLabel ?? t("common.required")}
+            </span>
+          )}
+        </Combobox.Label>
+      )}
+      <Combobox.Control className={styles.control} ref={triggerRef}>
         <div className={styles.iconBox}>
           <SerendieSymbolMagnifyingGlass className={styles.icon} />
         </div>
@@ -284,6 +327,19 @@ export const Search: React.FC<SearchStyleProps> = ({
           </Combobox.ClearTrigger>
         )}
       </Combobox.Control>
+      {invalid && invalidMessage && (
+        <div
+          className={css({
+            textStyle: {
+              base: "sd.system.typography.body.extraSmall_compact",
+              expanded: "sd.system.typography.body.extraSmall_expanded",
+            },
+            color: "sd.system.color.impression.negative",
+          })}
+        >
+          {invalidMessage}
+        </div>
+      )}
       <Portal disabled={!portalled} container={portalContainerRef}>
         <Combobox.Positioner>
           <Combobox.Content className={styles.combobox}>

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -43,6 +43,7 @@ export const SearchStyle = sva({
       rowGap: "sd.system.dimension.spacing.extraSmall",
     },
     control: {
+      display: "grid",
       width: "100%",
       lineHeight: "1",
       gridTemplateColumns: "auto 1fr auto",

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -274,6 +274,7 @@ export const Search: React.FC<SearchStyleProps> = ({
     <Combobox.Root
       {...elementProps}
       collection={collection}
+      required={required}
       invalid={invalid}
       className={cx(styles.root, className)}
       openOnClick
@@ -323,7 +324,7 @@ export const Search: React.FC<SearchStyleProps> = ({
           onChange={handleInputChange}
         />
         {hasValue && (
-          <Combobox.ClearTrigger className={styles.clearTrigger}>
+          <Combobox.ClearTrigger className={styles.clearTrigger} hidden={false}>
             <SerendieSymbolClose className={styles.icon} />
           </Combobox.ClearTrigger>
         )}

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import {
   Combobox,
   ComboboxRootProps,
+  ComboboxValueChangeDetails,
   Portal,
   createListCollection,
 } from "@ark-ui/react";
@@ -201,7 +202,6 @@ export const Search: React.FC<SearchStyleProps> = ({
   const [hasValue, setHasValue] = React.useState(
     () => !!(elementProps.inputValue || elementProps.defaultInputValue)
   );
-  const inputRef = React.useRef<HTMLInputElement>(null);
 
   const filteredItems = React.useMemo(() => {
     if (!inputValue) return items;
@@ -222,7 +222,7 @@ export const Search: React.FC<SearchStyleProps> = ({
   };
 
   // 候補選択時も検索を実行
-  const handleValueChange = (details: { value: string[] }) => {
+  const handleValueChange = (details: ComboboxValueChangeDetails<string>) => {
     if (details.value.length > 0) {
       onSearch?.(details.value[0]);
     }
@@ -246,19 +246,6 @@ export const Search: React.FC<SearchStyleProps> = ({
   // onChangeでhasValueを即時更新（onInputValueChangeより先に発火するため）
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setHasValue(e.target.value.length > 0);
-  };
-
-  // クリアボタンの処理
-  const handleClear = () => {
-    if (inputRef.current) {
-      inputRef.current.value = "";
-      inputRef.current.focus();
-    }
-    setHasValue(false);
-    if (!isControlled) {
-      setUncontrolledValue("");
-    }
-    elementProps.onInputValueChange?.({ inputValue: "" });
   };
 
   return (
@@ -287,19 +274,14 @@ export const Search: React.FC<SearchStyleProps> = ({
           <SerendieSymbolMagnifyingGlass className={styles.icon} />
         </div>
         <Combobox.Input
-          ref={inputRef}
           className={styles.input}
           onKeyDown={handleKeyDown}
           onChange={handleInputChange}
         />
         {hasValue && (
-          <button
-            type="button"
-            className={styles.clearTrigger}
-            onClick={handleClear}
-          >
+          <Combobox.ClearTrigger className={styles.clearTrigger}>
             <SerendieSymbolClose className={styles.icon} />
-          </button>
+          </Combobox.ClearTrigger>
         )}
       </Combobox.Control>
       <Portal disabled={!portalled} container={portalContainerRef}>


### PR DESCRIPTION
## Summary

Discussion [#613](https://github.com/orgs/serendie/discussions/613) で報告された Search の2件に対応。

**① クリア後に同じ候補を再選択できない不具合**

クリアボタンの処理が DOM を直接書き換えており、Ark UI のステートマシンを迂回していた。そのため Ark 内部には `value: ["Angular"]` / `inputValue: "Angular"` が残り、同じ候補を再選択しても値が変わらないため `onValueChange` が発火せず、入力欄も更新されなかった。

```diff
-<button type="button" onClick={handleClear}>   // inputRef.current.value = "" とDOMを直接操作
+<Combobox.ClearTrigger className={styles.clearTrigger}>  // Ark経由でvalue/inputValueをリセット
```

入力時に即座に×ボタンが表示される既存挙動（`hasValue` の `onChange` 即時更新）は維持している。

**② `label` プロパティの追加**

Inputs カテゴリで Search だけが `label` を持っていなかったため、Select と同じ命名・同じ見た目で `label` / `required` / `requiredLabel` / `invalid` / `invalidMessage` を追加。いずれも optional なので既存実装への影響はない。`Combobox.Label` により id と label が内部で自動配線される。

```tsx
<Search label="対象機器の検索" required placeholder="型番を入力してください" items={items} />
```

Select と揃えた仕様:
- `size="small"` のときはラベルを表示しない
- 必須ラベルは未指定時に i18n の `common.required` を使用
- `invalid` 時は control の outline を negative 色にし、`invalidMessage` を下部に表示

これに伴い `root` スロットを新設し、Select と同じ構造にするため `className` の付与先を Control から Root に変更した（幅指定 `min(100%, 300px)` も Root へ移動し、Control は `width: 100%` で追従）。

## 検証

Storybook に `WithLabel` / `Invalid` を追加し、`PlayDisplayMenu` に「候補を選択 → ×でクリア → 同じ候補を再選択」の回帰テストを追加（Search 分 9 tests passed）。main と Basic のスクリーンショットを比較し画像差分 0 で見た目のリグレッションがないことを確認。

| WithLabel | Invalid | 入力済み |
| --- | --- | --- |
| ![WithLabel](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfcmNaWFZEUWZvMnFxZTJGRCIsInVzZXJfaWQiOm51bGwsImJ1Y2tldF9uYW1lIjoiZGV2aW5hdHRhY2htZW50cyIsImJ1Y2tldF9rZXkiOiJhdHRhY2htZW50c19wcml2YXRlL29yZ19yY1pYVkRRZm8ycXFlMkZEL2NjNzU0YmYyLWVhYTItNGE3NS1hYjdhLTMzNGZjNWRiNjNmYSIsImlhdCI6MTc4NzgwMzk4NSwiZXhwIjoxNzg4NDA4Nzg1LCJmaWxlbmFtZSI6InNlYXJjaC13aXRoLWxhYmVsLWZpeGVkLnBuZyJ9.t159tOVRDxVMDTFCxR1bEECEleiWJBejKUuWTcIrbxk) | ![Invalid](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfcmNaWFZEUWZvMnFxZTJGRCIsInVzZXJfaWQiOm51bGwsImJ1Y2tldF9uYW1lIjoiZGV2aW5hdHRhY2htZW50cyIsImJ1Y2tldF9rZXkiOiJhdHRhY2htZW50c19wcml2YXRlL29yZ19yY1pYVkRRZm8ycXFlMkZELzBjYTUwMDJkLTY3OTctNDg4ZS05NTJmLWVjMmExMzIxZWQyYiIsImlhdCI6MTc4NzgwMzk4NiwiZXhwIjoxNzg4NDA4Nzg2LCJmaWxlbmFtZSI6InNlYXJjaC1pbnZhbGlkLWZpeGVkLnBuZyJ9.h5nhAwuwdl46SObGN-Is-6X-S_5JqGDFZ7NjT6AytKY) | ![WithValue](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfcmNaWFZEUWZvMnFxZTJGRCIsInVzZXJfaWQiOm51bGwsImJ1Y2tldF9uYW1lIjoiZGV2aW5hdHRhY2htZW50cyIsImJ1Y2tldF9rZXkiOiJhdHRhY2htZW50c19wcml2YXRlL29yZ19yY1pYVkRRZm8ycXFlMkZELzViMDFhMThiLTFmMDktNDhlYS1hNDZjLWI0NTlhZmM5ZDgwNSIsImlhdCI6MTc4NzgwMzk4NiwiZXhwIjoxNzg4NDA4Nzg2LCJmaWxlbmFtZSI6InNlYXJjaC13aXRoLXZhbHVlLWZpeGVkLnBuZyJ9.vd0qTn_baHZ-Zbtc_Y676wC6cB8JMSDmQKik1wagcDo) |


Link to Devin session: https://app.devin.ai/sessions/498d7cb4e801485ab1b9829283ea60a1
Requested by: @shibata-hiroyoshi