### PR TITLE
DropdownMenuのメニュー項目ごとにonSelectを指定できるようにした

### DIFF
--- a/src/components/DropdownMenu/DropdownMenu.stories.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.stories.tsx
@@ -4,6 +4,7 @@ import {
   SerendieSymbolPlaceholder,
 } from "@serendie/symbols";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
 import { DropdownMenu, DropdownMenuProps, MenuItemProps } from "./DropdownMenu";
 
 const meta: Meta<typeof DropdownMenu> = {
@@ -128,6 +129,44 @@ export const TrailingElement: Story = {
   render: (args: DropdownMenuProps) => (
     <DropdownMenu {...args} items={trailingItems} />
   ),
+  args: {
+    title: "メニュータイトル",
+  },
+};
+
+const ItemOnSelectTemplate = (args: DropdownMenuProps) => {
+  const [selected, setSelected] = useState<string>();
+  const items: MenuItemProps[] = [
+    {
+      label: "コピー",
+      value: "copy",
+      headingElement: <SerendieSymbolPlaceholder />,
+      onSelect: (value) => setSelected(value),
+    },
+    {
+      label: "編集",
+      value: "edit",
+      headingElement: <SerendieSymbolPlaceholder />,
+      onSelect: (value) => setSelected(value),
+    },
+    {
+      label: "削除",
+      value: "delete",
+      headingElement: <SerendieSymbolPlaceholder />,
+      onSelect: (value) => setSelected(value),
+    },
+  ];
+
+  return (
+    <div>
+      <DropdownMenu {...args} items={items} />
+      <p>選択されたアイテム: {selected ?? "なし"}</p>
+    </div>
+  );
+};
+
+export const ItemOnSelect: Story = {
+  render: ItemOnSelectTemplate,
   args: {
     title: "メニュータイトル",
   },

--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -67,6 +67,8 @@ export type MenuItemProps = {
   label: string;
   headingElement?: React.ReactElement;
   trailingElement?: React.ReactElement;
+  /** アイテムが選択されたときに呼び出される関数 */
+  onSelect?: (value: string) => void;
   /** @deprecated `icon` は廃止予定です。`headingElement` を使ってください */
   icon?: React.ReactElement;
 };
@@ -155,6 +157,11 @@ export const DropdownMenu: React.FC<DropdownMenuProps & MenuRootProps> = ({
                   key={item.value}
                   value={item.value}
                   className={styles.item}
+                  onSelect={
+                    item.onSelect
+                      ? () => item.onSelect?.(item.value)
+                      : undefined
+                  }
                 >
                   <ListItem
                     title={item.label}


### PR DESCRIPTION
## Summary

Discussion #608 でいただいた要望への対応です。これまで `DropdownMenu` の選択時の処理は、Root の `onSelect` の中で `value` による分岐を書く必要がありました。アイテム定義（`items`）側にハンドラを書けるようにして、分岐なしで済むようにしています。

```tsx
<DropdownMenu
  title="メニュータイトル"
  items={[
    { label: "コピー", value: "copy", onSelect: (value) => copy(value) },
    { label: "削除", value: "delete", onSelect: () => remove() },
  ]}
/>
```

- `MenuItemProps` に `onSelect?: (value: string) => void` を追加（optional なので破壊的変更なし）
- Ark UI の `Menu.Item` の `onSelect` は引数を取らない `VoidFunction` なので、内部で `() => item.onSelect?.(item.value)` にラップして `value` を受け取れるようにしています
- Root 側の `onSelect` とは共存可能（両方呼ばれる）
- Storybook に `ItemOnSelect` story を追加

なお、Discussion で併せて要望のあった「`DropdownMenu` / `ItemGroup` の width などのスタイル指定」は、デザイン仕様の意図（現在 `itemGroup` は `width: 240` 固定）を確認してから別途対応します。


Link to Devin session: https://app.devin.ai/sessions/7130a2e0c61444aaa8aadfb413262939
Requested by: @shibata-hiroyoshi