### PR TITLE
chore: Dependabotをセキュリティ更新のみに絞る

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,35 +4,20 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    cooldown:
-      default-days: 7
-    open-pull-requests-limit: 10
+    # バージョン更新を停止する（セキュリティ更新はこの上限の対象外）
+    open-pull-requests-limit: 0
     groups:
-      npm-minor-and-patch:
+      npm-security:
+        applies-to: "security-updates"
         patterns:
           - "*"
-        update-types:
-          - "minor"
-          - "patch"
-    ignore:
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-major"
-      - dependency-name: "eslint-plugin-react-refresh"
-        update-types:
-          - "version-update:semver-minor"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0
     groups:
-      actions-minor-and-patch:
+      actions-security:
+        applies-to: "security-updates"
         patterns:
           - "*"
-        update-types:
-          - "minor"
-          - "patch"
-    ignore:
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-major"


### PR DESCRIPTION
## 目的

Dependabot の PR を緊急性の高いもの（high / critical のセキュリティ更新）だけに絞ります。

## 変更内容（dependabot.yml）

- npm / github-actions ともに `open-pull-requests-limit: 0` でバージョン更新の PR を停止
  - セキュリティ更新はこの上限の対象外のため継続します
- セキュリティ更新は `applies-to: security-updates` のグループで 1 本の PR にまとめる
- `ignore`（semver-major）と `cooldown` を削除
  - major の ignore はセキュリティ更新にも適用され、修正版が major にしかない脆弱性の PR が出なくなるため
  - cooldown はもともとセキュリティ更新には適用されません

## マージ後に必要なリポジトリ設定（要管理者権限）

重大度での絞り込みは dependabot.yml では設定できないため、Settings 側で行います。

1. Settings → Advanced Security → 「Dependabot security updates」を **Disable**
   - ON のままだと、パッチのある全アラートに PR が開かれ続けます
2. 同ページ「Dependabot rules」→ New rule
   - 条件: Severity = `critical`, `high`
   - アクション: Open a pull request
3. GitHub プリセット「Dismiss low impact issues for development-scoped dependencies」は既定のまま維持

## 影響

- medium / low のアラートは PR が出なくなりますが、Dependabot alerts の一覧には残ります
- 現時点の未対応アラートは high 28 件、medium 27 件、low 5 件、critical 0 件です

参考: [Dependabot options reference](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference) / [Customizing auto-triage rules](https://docs.github.com/en/code-security/dependabot/dependabot-auto-triage-rules/customizing-auto-triage-rules-to-prioritize-dependabot-alerts)

https://claude.ai/code/session_01MkyNiRZZZL8izpSDJ2NgaZ