### PR TITLE
DropdownMenuの幅固定をやめて内容に合わせるようにした

### DIFF
--- a/src/components/DropdownMenu/DropdownMenu.stories.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.stories.tsx
@@ -132,3 +132,18 @@ export const TrailingElement: Story = {
     title: "メニュータイトル",
   },
 };
+
+const shortLabelItems: MenuItemProps[] = [
+  { label: "大", value: "large" },
+  { label: "中", value: "medium" },
+  { label: "小", value: "small" },
+];
+
+export const ShortLabel: Story = {
+  render: (args: DropdownMenuProps) => (
+    <DropdownMenu {...args} items={shortLabelItems} />
+  ),
+  args: {
+    title: "サイズ",
+  },
+};

--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -22,7 +22,8 @@ export const DropdownMenuStyle = sva({
       zIndex: "sd.system.elevation.zIndex.dropdown",
     },
     itemGroup: {
-      width: 240,
+      width: "fit-content",
+      minWidth: "112px",
     },
     item: {
       cursor: "pointer",


### PR DESCRIPTION
## Summary

Discussion #608 の「DropdownMenu / ItemGroup の width を指定できると嬉しい」という要望への対応です。デザイナー（下田さん）に確認し、幅固定をやめて内容に合わせる（Hug contents）＋最小幅のみ設定する方針になりました。

```diff
 itemGroup: {
-  width: 240,
+  width: "fit-content",
+  minWidth: "112px",
 },
```

- 最大幅は製品ごとに決められないため指定なし（デザイナー判断）
- Storybook に短いラベルの `ShortLabel` story を追加（最小幅が効いていることの確認用）

ローカルStorybookでの実測:

| story | itemGroup の幅 |
| --- | --- |
| Default（「リストタイトル」+ アイコン） | 169px（従来240px固定） |
| TrailingElement | 205px |
| ShortLabel（「大」「中」「小」） | 112px（min-width が効く） |

Chromatic では DropdownMenu 系storyの幅が縮む差分が出ます。


Link to Devin session: https://app.devin.ai/sessions/7130a2e0c61444aaa8aadfb413262939
Open in Devin Desktop: https://app.devin.ai/desktop/session/7130a2e0c61444aaa8aadfb413262939?variant=devin
Requested by: @shibata-hiroyoshi