### PR TITLE
SliderのStory名をWithMarkersに変更

### DIFF
--- a/src/components/Slider/Slider.stories.tsx
+++ b/src/components/Slider/Slider.stories.tsx
@@ -95,7 +95,7 @@ export const Disabled: Story = {
   },
 };
 
-export const WithMarkerValues: Story = {
+export const WithMarkers: Story = {
   args: {
     startLabel: "Value",
     endLabel: "Value",


### PR DESCRIPTION
## Summary

SliderのStory名 `WithMarkerValues` を `WithMarkers` に変更し、`WithoutMarkers` との対比を分かりやすくする（マーカーあり／なし）。

- Storybook上の表示が "With Marker Values" → "With Markers" になる
- Story URLが `/story/components-slider--with-marker-values` → `/story/components-slider--with-markers` に変わるため、serendie-web側のstoryPathも追従する（対PR: serendie/serendie-web#139 相当の追従PR）

cc @serendie/core-devs

Link to Devin session: https://app.devin.ai/sessions/3059d211660549509e84bb110e019150
Open in Devin Desktop: https://app.devin.ai/desktop/session/3059d211660549509e84bb110e019150?variant=devin
Requested by: @NakataniYuta