### PR TITLE
chore: Dependabotに@serendie/*のバージョン更新エントリを追加する

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,21 @@ updates:
         applies-to: "security-updates"
         patterns:
           - "*"
+  # @serendie/* のバージョン更新用。
+  # target-branch を指定したエントリの設定はセキュリティ更新に使われないため、
+  # allow で絞ってもセキュリティ更新が止まらない
+  - package-ecosystem: "npm"
+    directory: "/"
+    target-branch: "main"
+    schedule:
+      interval: "weekly"
+    allow:
+      - dependency-name: "@serendie/*"
+    groups:
+      serendie:
+        patterns:
+          - "@serendie/*"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## 目的

#253 でバージョン更新を全停止した際、@serendie/design-token や @serendie/symbols の追従 PR も止まっていました。内部パッケージの更新だけ Dependabot で受け取れるようにします。

## 設計の理由

- `allow: "@serendie/*"` を既存エントリに足す形はとれません。allow はセキュリティ更新にも効き、他パッケージの脆弱性修正 PR が止まるためです（style-dictionary-formatter の実機で確認済み）
- 代わりに `target-branch: main` 付きの第 2 エントリに分けています。target-branch 付きエントリの設定はセキュリティ更新に使われないため、allow で絞っても影響しません
- この 2 エントリ構成は subbrands-template で検証済みです。@serendie/* のバージョン更新 PR（serendie/subbrands-template#5）とセキュリティ更新のまとめ PR（serendie/subbrands-template#7）の両方が出ることを確認しました

## 注意

subbrands-template では設定導入後、初回のセキュリティ更新だけが約 5 日遅れました（アラート画面に「Dependabot has taken too long to create an update」が表示され続けた後、自然に回復）。同じ遅延が出た場合は数日待ってから判断してください。

https://claude.ai/code/session_01MkyNiRZZZL8izpSDJ2NgaZ