### PR TITLE
@figma/code-connect を名前付き import に統一して Vite 8 で Storybook が落ちる問題を修正

### DIFF
--- a/src/components/Accordion/Accordion.stories.tsx
+++ b/src/components/Accordion/Accordion.stories.tsx
@@ -1,4 +1,4 @@
-import figma from "@figma/code-connect";
+import { figma } from "@figma/code-connect";
 import { Meta, StoryObj } from "@storybook/react-vite";
 import { AccordionGroup } from "./AccordionGroup";
 import { Accordion, AccordionProps } from "./Accordion";

--- a/src/components/Avatar/Avatar.stories.tsx
+++ b/src/components/Avatar/Avatar.stories.tsx
@@ -1,4 +1,4 @@
-import figma from "@figma/code-connect";
+import { figma } from "@figma/code-connect";
 import { Meta, StoryObj } from "@storybook/react-vite";
 import { Avatar } from "./Avatar";
 

--- a/src/components/Badge/Badge.stories.tsx
+++ b/src/components/Badge/Badge.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from "@storybook/react-vite";
 import { Badge, BadgeCloseButton, BadgeStyle } from "./Badge";
-import figma from "@figma/code-connect";
+import { figma } from "@figma/code-connect";
 
 const meta: Meta<typeof Badge> = {
   component: Badge,

--- a/src/components/Banner/Banner.stories.tsx
+++ b/src/components/Banner/Banner.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from "@storybook/react-vite";
 import { Banner } from "./Banner";
-import figma from "@figma/code-connect";
+import { figma } from "@figma/code-connect";
 
 const meta: Meta<typeof Banner> = {
   component: Banner,

--- a/src/components/BottomNavigation/BottomNavigation.stories.tsx
+++ b/src/components/BottomNavigation/BottomNavigation.stories.tsx
@@ -4,7 +4,7 @@ import {
   BottomNavigationItem,
   BottomNavigationItemProps,
 } from "./BottomNavigationItem";
-import figma from "@figma/code-connect";
+import { figma } from "@figma/code-connect";
 import { SerendieSymbolMagnifyingGlass } from "@serendie/symbols";
 
 const meta: Meta<typeof BottomNavigationItem> = {

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { Button, ButtonStyle } from "./Button";
-import figma from "@figma/code-connect";
+import { figma } from "@figma/code-connect";
 import {
   SerendieSymbolChevronLeft,
   SerendieSymbolChevronRight,

--- a/src/components/CheckBox/CheckBox.stories.tsx
+++ b/src/components/CheckBox/CheckBox.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { CheckBox, CheckBoxProps } from "./CheckBox";
-import figma from "@figma/code-connect";
+import { figma } from "@figma/code-connect";
 
 const meta: Meta<typeof CheckBox> = {
   component: CheckBox,

--- a/src/components/ChoiceBox/ChoiceBox.stories.tsx
+++ b/src/components/ChoiceBox/ChoiceBox.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { ChoiceBox } from "./ChoiceBox";
 import { RadioGroup } from "../RadioButton";
-import figma from "@figma/code-connect";
+import { figma } from "@figma/code-connect";
 
 const meta: Meta<typeof ChoiceBox> = {
   component: ChoiceBox,

--- a/src/components/DashboardWidget/DashboardWidget.stories.tsx
+++ b/src/components/DashboardWidget/DashboardWidget.stories.tsx
@@ -1,4 +1,4 @@
-import figma from "@figma/code-connect";
+import { figma } from "@figma/code-connect";
 import { Meta, StoryObj } from "@storybook/react-vite";
 import { css } from "../../../styled-system/css";
 import { DashboardWidget } from "./DashboardWidget";

--- a/src/components/DatePicker/DatePicker.stories.tsx
+++ b/src/components/DatePicker/DatePicker.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { DatePicker } from "./DatePicker";
-import figma from "@figma/code-connect";
+import { figma } from "@figma/code-connect";
 import { useState } from "react";
 import {
   DatePickerValueChangeDetails,

--- a/src/components/Divider/Divider.stories.tsx
+++ b/src/components/Divider/Divider.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from "@storybook/react-vite";
 import { Divider, DividerStyle } from "./Divider";
-import figma from "@figma/code-connect";
+import { figma } from "@figma/code-connect";
 
 const meta: Meta<typeof Divider> = {
   component: Divider,

--- a/src/components/Drawer/Drawer.stories.tsx
+++ b/src/components/Drawer/Drawer.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from "@storybook/react-vite";
 import { Drawer, DrawerProps } from "./Drawer";
 import { useState } from "react";
 import { IconButton } from "../IconButton";
-import figma from "@figma/code-connect";
+import { figma } from "@figma/code-connect";
 import { SerendieSymbolMenu } from "@serendie/symbols";
 import { userEvent, within, waitFor, expect } from "storybook/test";
 import { FullscreenLayout } from "../../../.storybook/FullscreenLayout";

--- a/src/components/DropdownMenu/DropdownMenu.stories.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.stories.tsx
@@ -1,4 +1,4 @@
-import figma from "@figma/code-connect";
+import { figma } from "@figma/code-connect";
 import {
   SerendieSymbolMenu,
   SerendieSymbolPlaceholder,

--- a/src/components/IconButton/IconButton.stories.tsx
+++ b/src/components/IconButton/IconButton.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { IconButton, IconButtonStyle } from "./IconButton";
-import figma from "@figma/code-connect";
+import { figma } from "@figma/code-connect";
 import { SerendieSymbolPlus } from "@serendie/symbols";
 
 const meta: Meta<typeof IconButton> = {

--- a/src/components/List/ListItem.stories.tsx
+++ b/src/components/List/ListItem.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { ListItem } from "./ListItem";
 import { List } from "./List";
-import figma from "@figma/code-connect";
+import { figma } from "@figma/code-connect";
 import {
   SerendieSymbolChevronRight,
   SerendieSymbolPlaceholder,

--- a/src/components/ModalDialog/ModalDialog.stories.tsx
+++ b/src/components/ModalDialog/ModalDialog.stories.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { Button } from "../Button";
 import { DropdownMenu } from "../DropdownMenu";
 import { SerendieSymbolPlaceholder } from "@serendie/symbols";
-import figma from "@figma/code-connect";
+import { figma } from "@figma/code-connect";
 import { expect, userEvent, waitFor, within } from "storybook/test";
 import { allModes } from "../../../.storybook/modes";
 import { FullscreenLayout } from "../../../.storybook/FullscreenLayout";

--- a/src/components/NotificationBadge/NotificationBadge.stories.tsx
+++ b/src/components/NotificationBadge/NotificationBadge.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { NotificationBadge } from "./NotificationBadge";
-import figma from "@figma/code-connect";
+import { figma } from "@figma/code-connect";
 
 const meta: Meta<typeof NotificationBadge> = {
   component: NotificationBadge,

--- a/src/components/PasswordField/PasswordField.stories.tsx
+++ b/src/components/PasswordField/PasswordField.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { PasswordField } from "./PasswordField";
-import figma from "@figma/code-connect";
+import { figma } from "@figma/code-connect";
 import { TextField } from "../TextField";
 
 const meta: Meta<typeof PasswordField> = {

--- a/src/components/RadioButton/RadioButton.stories.tsx
+++ b/src/components/RadioButton/RadioButton.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { RadioButton, RadioButtonProps } from "./RadioButton";
 import { RadioGroup } from "./RadioGroup";
-import figma from "@figma/code-connect";
+import { figma } from "@figma/code-connect";
 
 const meta: Meta<typeof RadioButton> = {
   component: RadioButton,

--- a/src/components/Search/Search.stories.tsx
+++ b/src/components/Search/Search.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { Search } from "./Search";
-import figma from "@figma/code-connect";
+import { figma } from "@figma/code-connect";
 import { fn, userEvent, within, waitFor, expect } from "storybook/test";
 import { FullscreenLayout } from "../../../.storybook/FullscreenLayout";
 

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -1,4 +1,4 @@
-import figma from "@figma/code-connect";
+import { figma } from "@figma/code-connect";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { userEvent, within, waitFor, expect } from "storybook/test";
 import { FullscreenLayout } from "../../../.storybook/FullscreenLayout";

--- a/src/components/Slider/Slider.stories.tsx
+++ b/src/components/Slider/Slider.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { Slider } from "./Slider";
-import figma from "@figma/code-connect";
+import { figma } from "@figma/code-connect";
 
 const meta: Meta<typeof Slider> = {
   component: Slider,

--- a/src/components/Steps/Steps.stories.tsx
+++ b/src/components/Steps/Steps.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { Steps } from "./Steps";
-import figma from "@figma/code-connect";
+import { figma } from "@figma/code-connect";
 
 const meta: Meta<typeof Steps> = {
   component: Steps,

--- a/src/components/Switch/Switch.stories.tsx
+++ b/src/components/Switch/Switch.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { Switch, SwitchProps } from "./Switch";
-import figma from "@figma/code-connect";
+import { figma } from "@figma/code-connect";
 
 const meta: Meta<typeof Switch> = {
   component: Switch,

--- a/src/components/Tabs/Tabs.stories.tsx
+++ b/src/components/Tabs/Tabs.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { Tabs } from "./Tabs";
 import { TabItem, TabItemProps } from "./TabItem";
-import figma from "@figma/code-connect";
+import { figma } from "@figma/code-connect";
 
 const meta: Meta<typeof TabItem> = {
   component: TabItem,

--- a/src/components/TextArea/TextArea.stories.tsx
+++ b/src/components/TextArea/TextArea.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { TextArea } from "./TextArea";
-import figma from "@figma/code-connect";
+import { figma } from "@figma/code-connect";
 
 const meta: Meta<typeof TextArea> = {
   component: TextArea,

--- a/src/components/TextField/TextField.stories.tsx
+++ b/src/components/TextField/TextField.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { TextField } from "./TextField";
-import figma from "@figma/code-connect";
+import { figma } from "@figma/code-connect";
 import {
   SerendieSymbolInformation,
   SerendieSymbolMail,

--- a/src/components/Toast/Toast.stories.tsx
+++ b/src/components/Toast/Toast.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { Toast, toaster } from "./Toast";
 import { Button } from "../Button";
 import { Stack } from "../../../styled-system/jsx";
-import figma from "@figma/code-connect";
+import { figma } from "@figma/code-connect";
 import { userEvent, within, waitFor, expect } from "storybook/test";
 import { FullscreenLayout } from "../../../.storybook/FullscreenLayout";
 

--- a/src/components/TopAppBar/TopAppBar.stories.tsx
+++ b/src/components/TopAppBar/TopAppBar.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta, StoryObj } from "@storybook/react-vite";
 import { TopAppBar } from "./TopAppBar";
 import { IconButton } from "../IconButton";
-import figma from "@figma/code-connect";
+import { figma } from "@figma/code-connect";
 import React from "react";
 import {
   SerendieSymbolMagnifyingGlass,


### PR DESCRIPTION
#254 で vite が 8 に上がって以降、Chromatic が `g.default.string is not a function` で失敗しているのを修正します。

Vite 8（Rolldown）では `@figma/code-connect` の default import が `figma.default` に解決されるため、名前付き import `import { figma }` に統一しました（29 ファイル、各 1 行）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)